### PR TITLE
Implement monetizable agent services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # AI Agents
+
+This repository contains sample FastAPI-based AI agent services. Each agent
+implements a small task that could be monetized as a standalone API. The
+available agents are:
+
+- **FinanceAgent** – calculates return on investment via `/roi`.
+- **HealthcareAgent** – computes Body Mass Index via `/bmi`.
+- **LegalAgent** – provides very basic text summarization via `/summarize`.
+- **RetailAgent** – calculates discounted prices via `/discount`.
+
+## Running an agent
+
+Each agent class can be started individually:
+
+```bash
+python -m agents.finance_agent
+```
+
+The default ports are 8001–8004 for the four agents. Once running, send JSON
+payloads to the respective endpoints to receive results.
+
+These simple examples demonstrate how domain-specific services can be created
+and offered through an API for potential monetization.

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,1 @@
+# Agent package

--- a/agents/finance_agent.py
+++ b/agents/finance_agent.py
@@ -1,0 +1,26 @@
+from fastapi import Body
+from core.base_agent import BaseAIAgent
+
+
+class FinanceAgent(BaseAIAgent):
+    def __init__(self, port: int = 8001):
+        super().__init__("finance", port)
+
+    def setup_routes(self):
+        @self.app.post("/roi")
+        async def roi(data: dict = Body(...)):
+            initial = data.get("initial")
+            final = data.get("final")
+            if initial is None or final is None:
+                return {"error": "'initial' and 'final' are required"}
+            try:
+                roi_value = (float(final) - float(initial)) / float(initial) * 100
+            except (ValueError, ZeroDivisionError):
+                return {"error": "Invalid numeric values"}
+            return {"roi": roi_value}
+
+    async def process_task(self, input_data: dict):
+        return await self.app.router.routes[0].endpoint(input_data)
+
+if __name__ == "__main__":
+    FinanceAgent().run()

--- a/agents/healthcare_agent.py
+++ b/agents/healthcare_agent.py
@@ -1,0 +1,26 @@
+from fastapi import Body
+from core.base_agent import BaseAIAgent
+
+
+class HealthcareAgent(BaseAIAgent):
+    def __init__(self, port: int = 8002):
+        super().__init__("healthcare", port)
+
+    def setup_routes(self):
+        @self.app.post("/bmi")
+        async def bmi(data: dict = Body(...)):
+            weight = data.get("weight")
+            height = data.get("height")
+            if weight is None or height is None:
+                return {"error": "'weight' and 'height' are required"}
+            try:
+                bmi_val = float(weight) / (float(height) ** 2)
+            except (ValueError, ZeroDivisionError):
+                return {"error": "Invalid numeric values"}
+            return {"bmi": bmi_val}
+
+    async def process_task(self, input_data: dict):
+        return await self.app.router.routes[0].endpoint(input_data)
+
+if __name__ == "__main__":
+    HealthcareAgent().run()

--- a/agents/legal_agent.py
+++ b/agents/legal_agent.py
@@ -1,0 +1,28 @@
+import re
+from fastapi import Body
+from core.base_agent import BaseAIAgent
+
+
+def simple_summarize(text: str, sentences: int = 2) -> str:
+    parts = re.split(r"(?<=[.!?]) +", text)
+    return " ".join(parts[:sentences])
+
+
+class LegalAgent(BaseAIAgent):
+    def __init__(self, port: int = 8003):
+        super().__init__("legal", port)
+
+    def setup_routes(self):
+        @self.app.post("/summarize")
+        async def summarize(data: dict = Body(...)):
+            text = data.get("text")
+            if not text:
+                return {"error": "'text' is required"}
+            summary = simple_summarize(str(text))
+            return {"summary": summary}
+
+    async def process_task(self, input_data: dict):
+        return await self.app.router.routes[0].endpoint(input_data)
+
+if __name__ == "__main__":
+    LegalAgent().run()

--- a/agents/retail_agent.py
+++ b/agents/retail_agent.py
@@ -1,0 +1,26 @@
+from fastapi import Body
+from core.base_agent import BaseAIAgent
+
+
+class RetailAgent(BaseAIAgent):
+    def __init__(self, port: int = 8004):
+        super().__init__("retail", port)
+
+    def setup_routes(self):
+        @self.app.post("/discount")
+        async def discount(data: dict = Body(...)):
+            price = data.get("price")
+            percentage = data.get("percentage")
+            if price is None or percentage is None:
+                return {"error": "'price' and 'percentage' are required"}
+            try:
+                final_price = float(price) * (1 - float(percentage) / 100)
+            except ValueError:
+                return {"error": "Invalid numeric values"}
+            return {"discounted_price": final_price}
+
+    async def process_task(self, input_data: dict):
+        return await self.app.router.routes[0].endpoint(input_data)
+
+if __name__ == "__main__":
+    RetailAgent().run()

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+# Core package


### PR DESCRIPTION
## Summary
- implement simple FastAPI agents for finance, healthcare, legal and retail
- add package initialization files
- document how to run the services in README

## Testing
- `python -m py_compile agents/*.py core/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684494a8a06c832eb730b490c530736a