### PR TITLE
Add initial AAPT model scaffolds

### DIFF
--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,0 +1,16 @@
+from .transformer import AAPTTransformer
+from .vae import AAPTVAE
+
+
+def load_model() -> tuple[AAPTTransformer, AAPTVAE]:
+    """Instantiate the core models used in AAPT.
+
+    Returns:
+        Tuple containing the transformer and VAE models.
+    """
+    transformer = AAPTTransformer()
+    vae = AAPTVAE()
+    print("AAPT models loaded: transformer and VAE initialized")
+    return transformer, vae
+
+__all__ = ["AAPTTransformer", "AAPTVAE", "load_model"]

--- a/model/transformer.py
+++ b/model/transformer.py
@@ -1,0 +1,22 @@
+import torch
+from torch import nn
+
+class AAPTTransformer(nn.Module):
+    """Placeholder transformer model for AAPT video generation."""
+
+    def __init__(self):
+        super().__init__()
+        # TODO: replace with real transformer blocks and attention layers
+        self.dummy_layer = nn.Linear(512, 512)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply the model to the input tensor.
+
+        Args:
+            x: Input tensor of shape ``(batch, seq_len, 512)``.
+
+        Returns:
+            torch.Tensor: Output tensor after dummy transformation.
+        """
+        return self.dummy_layer(x)
+

--- a/model/vae.py
+++ b/model/vae.py
@@ -1,0 +1,21 @@
+import torch
+from torch import nn
+
+class AAPTVAE(nn.Module):
+    """Placeholder variational autoencoder for AAPT video generation."""
+
+    def __init__(self):
+        super().__init__()
+        # Encoder and decoder are simple linear layers for now
+        # TODO: implement real latent encoding and decoding
+        self.encoder = nn.Linear(512, 256)
+        self.decoder = nn.Linear(256, 512)
+
+    def encode(self, x: torch.Tensor) -> torch.Tensor:
+        """Encode the input into a latent representation."""
+        return self.encoder(x)
+
+    def decode(self, z: torch.Tensor) -> torch.Tensor:
+        """Decode the latent representation back to the input space."""
+        return self.decoder(z)
+


### PR DESCRIPTION
## Summary
- add placeholder transformer implementation
- add placeholder VAE implementation
- expose a `load_model` helper in `model/__init__`

## Testing
- `python -m compileall -q model`

------
https://chatgpt.com/codex/tasks/task_e_6856bacd4044832eacfcf4e7f2c5711f