### PR TITLE
Implement memory layer for agent session tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,24 @@ This repository provides a starting point for building a real-time AI video gene
 
 ### Folder Structure
 
-- `model/` – Code for the transformer, VAE, and related components.
-- `train/` – Training loops implementing student-forcing and other strategies.
-- `inference/` – Scripts and utilities for running the model to produce videos.
-- `configs/` – YAML configuration files (resolution, attention window, etc.).
-- `utils/` – Helper functions for logging, decoding, and more.
+- `model/` - Code for the transformer, VAE, and related components.
+- `train/` - Training loops implementing student-forcing and other strategies.
+- `inference/` - Scripts and utilities for running the model to produce videos.
+- `configs/` - YAML configuration files (resolution, attention window, etc.).
+- `utils/` - Helper functions for logging, decoding, and more.
 
 This project is currently a scaffold and will evolve as development progresses. Contributions are welcome!
 
 ## AITaskFlo
 
 This repository also includes **AITaskFlo**, an example automation system built with multiple intelligent agents. Each agent can process specialized tasks such as finance calculations, legal clause extraction, and retail inventory suggestions. A FastAPI gateway exposes a simple HTTP interface.
+
+### Agent Memory
+
+`AITaskFlo` ships with a lightweight JSON memory layer that records each
+request and response per session. The controller generates a session ID
+when one is not supplied. Inspect stored history or run a quick demo via:
+
+```bash
+python controller.py --test-memory
+```

--- a/app.py
+++ b/app.py
@@ -26,6 +26,8 @@ if st.button("Run"):
 
 if controller.memory:
     st.subheader("History")
-    for row in controller.memory.fetch_all():
-        st.write(row)
+    for sid, entries in controller.memory.fetch_all().items():
+        st.write(f"Session {sid}:")
+        for item in entries:
+            st.json(item)
 

--- a/memory.py
+++ b/memory.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 
@@ -41,3 +42,45 @@ class Memory:
             "SELECT timestamp, agent, input, output FROM history ORDER BY id DESC"
         )
         return cur.fetchall()
+
+
+class MemoryManager:
+    """JSON-based memory manager for per-session conversation storage."""
+
+    def __init__(self, path: str = "memory_store.json") -> None:
+        base_path = Path(path)
+        if not base_path.is_absolute():
+            base_path = Path(__file__).resolve().parent / base_path
+        self.path = base_path
+        if self.path.exists():
+            try:
+                self.store: Dict[str, List[Dict[str, Any]]] = json.loads(
+                    self.path.read_text(encoding="utf-8") or "{}"
+                )
+            except json.JSONDecodeError:
+                self.store = {}
+        else:
+            self.store = {}
+            self.path.write_text("{}", encoding="utf-8")
+
+    def _persist(self) -> None:
+        self.path.write_text(json.dumps(self.store, indent=2), encoding="utf-8")
+
+    def log(self, session_id: str, user_input: Any, response: Any) -> None:
+        """Append a conversation turn to a session."""
+        entry = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "input": user_input,
+            "response": response,
+        }
+        self.store.setdefault(session_id, []).append(entry)
+        self._persist()
+
+    def recall(self, session_id: str) -> List[Dict[str, Any]]:
+        """Return the conversation history for a session."""
+        return self.store.get(session_id, [])
+
+    def fetch_all(self) -> Dict[str, List[Dict[str, Any]]]:
+        """Return the entire memory store."""
+        return self.store
+


### PR DESCRIPTION
## Summary
- implement a JSON-based `MemoryManager` for session logs
- store and recall conversations per session in `controller.py`
- expose a simple memory testing CLI via `--test-memory`
- display session history in the Streamlit demo
- return generated session ID in each response and store logs relative to `memory.py`

## Testing
- `python controller.py --test-memory`


------
https://chatgpt.com/codex/tasks/task_e_6856d90e0404832eb73097cdd2323738