### PR TITLE
Add dream world simulator and guardian protocols

### DIFF
--- a/dream_world_sim.py
+++ b/dream_world_sim.py
@@ -1,0 +1,13 @@
+class DreamWorldSim:
+    """Rudimentary engine that generates abstract 'dream' concepts."""
+
+    def __init__(self) -> None:
+        self.log = []
+
+    def simulate(self, topic: str) -> dict:
+        """Return a basic dream visualization for a topic."""
+        vision = f"Envisioning peaceful resolution of {topic}."
+        loop = f"Reflection on {topic} repeats gently."
+        result = {"vision": vision, "loop": loop}
+        self.log.append(result)
+        return result

--- a/frontend_agent.py
+++ b/frontend_agent.py
@@ -5,6 +5,8 @@ import uuid
 from typing import Any, Dict
 
 from memory import MemoryManager
+from dream_world_sim import DreamWorldSim
+from guardian_protocols import GuardianProtocols
 
 
 class EmotionEngine:
@@ -58,6 +60,8 @@ class FrontendAgent:
         self.memory = MemoryManager(path=memory_path)
         self.emotion_engine = EmotionEngine()
         self.logic_engine = QuantumLogicEngine()
+        self.dream_engine = DreamWorldSim()
+        self.guardian = GuardianProtocols()
 
     def generate_response(self, text: str, logic: Dict[str, Any]) -> str:
         """Return a rudimentary response based on the chosen logic path."""
@@ -77,14 +81,23 @@ class FrontendAgent:
         text = input_data.get("text", "")
         metadata = {k: v for k, v in input_data.items() if k not in {"session_id", "text"}}
 
+        protection = self.guardian.evaluate(text)
+        if protection["status"] == "neutralized":
+            result = {"session_id": session_id, "guardian": protection}
+            self.memory.log(session_id, input_data, result)
+            return result
+
         emotion = self.emotion_engine.analyze(text)
         logic = self.logic_engine.process(text, emotion, metadata)
         response = self.generate_response(text, logic)
+        dream = self.dream_engine.simulate(text)
 
         result = {
             "session_id": session_id,
             "emotion": emotion,
             "logic": logic,
+            "dream": dream,
+            "guardian": protection,
             "response": response,
         }
 

--- a/guardian_protocols.py
+++ b/guardian_protocols.py
@@ -1,0 +1,11 @@
+class GuardianProtocols:
+    """Basic safeguards against negative input or overload."""
+
+    NEGATIVE_KEYWORDS = {"threat", "attack", "hate", "angry"}
+
+    def evaluate(self, text: str) -> dict:
+        """Return a protection status and message."""
+        lowered = text.lower()
+        if any(word in lowered for word in self.NEGATIVE_KEYWORDS):
+            return {"status": "neutralized", "message": "Neutralized threat, standing down."}
+        return {"status": "clear", "message": "All clear."}


### PR DESCRIPTION
## Summary
- implement `dream_world_sim.py` for basic dream visualization
- implement `guardian_protocols.py` to check negative input
- integrate both modules into `frontend_agent.py`

## Testing
- `python controller.py --test-memory`
- manual checks of `FrontendAgent` via Python REPL

------
https://chatgpt.com/codex/tasks/task_e_6856ea107730832ead883859fa2310ca