### PR TITLE
Add perceptual loop and contextual response system

### DIFF
--- a/frontend_agent.py
+++ b/frontend_agent.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 from memory import MemoryManager
 from dream_world_sim import DreamWorldSim
 from guardian_protocols import GuardianProtocols
+from scene_context import SceneContextManager
 
 
 class EmotionEngine:
@@ -62,19 +63,25 @@ class FrontendAgent:
         self.logic_engine = QuantumLogicEngine()
         self.dream_engine = DreamWorldSim()
         self.guardian = GuardianProtocols()
+        self.scene_manager = SceneContextManager()
 
-    def generate_response(self, text: str, logic: Dict[str, Any]) -> str:
-        """Return a rudimentary response based on the chosen logic path."""
+    def generate_response(self, text: str, logic: Dict[str, Any], context: Dict[str, Any]) -> str:
+        """Return a rudimentary response based on the chosen logic path with scene context."""
         path = logic.get("path")
         if path == "logical":
-            return f"Understood: {text}"
-        if path == "emotional":
-            return f"I sense strong feelings in: '{text}'"
-        if path == "symbolic":
-            return f"🔮 {text}"
-        if path == "chaotic":
-            return text[::-1]
-        return text
+            base = f"Understood: {text}"
+        elif path == "emotional":
+            base = f"I sense strong feelings in: '{text}'"
+        elif path == "symbolic":
+            base = f"🔮 {text}"
+        elif path == "chaotic":
+            base = text[::-1]
+        else:
+            base = text
+        return (
+            f"In this {context['emotion']} moment beneath the {context['surroundings']}, "
+            f"{base}"
+        )
 
     async def handle(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
         session_id = input_data.get("session_id") or uuid.uuid4().hex
@@ -89,7 +96,9 @@ class FrontendAgent:
 
         emotion = self.emotion_engine.analyze(text)
         logic = self.logic_engine.process(text, emotion, metadata)
-        response = self.generate_response(text, logic)
+        self.scene_manager.update_scene(text)
+        context = self.scene_manager.get_context()
+        response = self.generate_response(text, logic, context)
         dream = self.dream_engine.simulate(text)
 
         result = {
@@ -98,6 +107,7 @@ class FrontendAgent:
             "logic": logic,
             "dream": dream,
             "guardian": protection,
+            "context": context,
             "response": response,
         }
 

--- a/scene_context.py
+++ b/scene_context.py
@@ -1,0 +1,21 @@
+class SceneContextManager:
+    """Manage time, emotional atmosphere, and surroundings for the agent."""
+
+    def __init__(self) -> None:
+        self.current_scene = {
+            "time": "dusk",
+            "emotion": "curious",
+            "surroundings": "twilight forest",
+        }
+
+    def update_scene(self, input_data: str) -> None:
+        """Update scene details based on the latest user input."""
+        lowered = input_data.lower()
+        if "cold" in lowered:
+            self.current_scene["surroundings"] = "frozen temple"
+        if "love" in lowered:
+            self.current_scene["emotion"] = "enchanted"
+
+    def get_context(self) -> dict:
+        """Return the current scene context."""
+        return self.current_scene


### PR DESCRIPTION
## Summary
- add `SceneContextManager` for scene-based contextual data
- integrate scene context into `FrontendAgent` responses

## Testing
- `python -m py_compile scene_context.py frontend_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6856eda58e94832e9b763bbcbb71c5fb