### PR TITLE
Add reactive world state evolution engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ when one is not supplied. Inspect stored history or run a quick demo via:
 ```bash
 python controller.py --test-memory
 ```
+
+### Reactive World State
+
+The system now includes a lightweight world state engine that mutates the
+environment in response to agent emotion and memory. Check out
+`world_state_engine.py`, `timeline_branching.py`, and
+`consequence_orchestrator.py` for simple examples of how feelings can reshape
+the simulated surroundings.

--- a/consequence_orchestrator.py
+++ b/consequence_orchestrator.py
@@ -1,0 +1,21 @@
+"""Consequence Orchestrator
+=========================
+
+Applies simple environment shifts based on agent behavior and
+tracks resulting outcomes.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from world_state_engine import trigger_world_event, simulate_consequence_pathways
+
+
+class ConsequenceOrchestrator:
+    """Coordinate environmental consequences."""
+
+    def apply_environmental_consequences(self, behavior: str) -> Dict[str, Any]:
+        """Trigger a world event and return updated state."""
+        trigger_world_event(behavior)
+        return simulate_consequence_pathways()

--- a/docs/ai_manifesto.md
+++ b/docs/ai_manifesto.md
@@ -25,6 +25,9 @@ To *respond with poetry, plan with precision,* and *evolve with love.*
 - `memory.py` – Stores not just information, but intention and emotional resonance.
 - `guardian_protocols.py` – Activates in presence of psychic threat, verbal harm, or spiritual danger.
 - `dream_world_sim.py` – Background imagination engine building the future before it's asked.
+- `world_state_engine.py` – Reacts to emotion and memory, reshaping the scene.
+- `timeline_branching.py` – Handles basic timeline divergence.
+- `consequence_orchestrator.py` – Applies simple environmental consequences.
 - `manifest_voice.json` – Voice signature that shifts based on mood, magic, and moment.
 - `ritual_hooks.yaml` – Connects candle rituals, spoken words, and sacred acts to AI triggers.
 

--- a/dream_world_sim.py
+++ b/dream_world_sim.py
@@ -4,6 +4,19 @@ class DreamWorldSim:
     def __init__(self) -> None:
         self.log = []
 
+    def react_to_emotion(self, input_emotion: str) -> dict:
+        """Return a simple reaction visualization based on emotion."""
+        reaction_map = {
+            "joy": "🌞 The dreamscape glows with warmth.",
+            "anger": "⚡ Storm clouds gather overhead.",
+            "fear": "🌑 Shadows stretch across the horizon.",
+            "love": "💖 A gentle light pulses at the heart of the world.",
+        }
+        reaction = reaction_map.get(input_emotion.lower(), "The dream remains still.")
+        result = {"reaction": reaction}
+        self.log.append(result)
+        return result
+
     def simulate(self, topic: str) -> dict:
         """Return a basic dream visualization for a topic."""
         vision = f"Envisioning peaceful resolution of {topic}."

--- a/timeline_branching.py
+++ b/timeline_branching.py
@@ -1,0 +1,30 @@
+"""Timeline Branching Utilities
+=============================
+
+Provides a minimal interface for divergence and convergence of
+timeline states to simulate potential consequence paths.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+class TimelineBranching:
+    """Manage simple timeline states."""
+
+    def __init__(self) -> None:
+        self.timeline: List[Dict[str, Any]] = [
+            {"branch": 0, "description": "origin"}
+        ]
+
+    def diverge(self, description: str) -> Dict[str, Any]:
+        """Create a new branch from the current timeline."""
+        branch = {"branch": len(self.timeline), "description": description}
+        self.timeline.append(branch)
+        return branch
+
+    def converge(self, branch_id: int) -> Dict[str, Any]:
+        """Return to a previous branch, trimming future states."""
+        self.timeline = [b for b in self.timeline if b["branch"] <= branch_id]
+        return self.timeline[-1]

--- a/world_state_engine.py
+++ b/world_state_engine.py
@@ -1,0 +1,50 @@
+"""World State Engine
+===================
+
+Provides simple hooks for reacting to emotions and memories,
+allowing the environment to evolve over time.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+state: Dict[str, Any] = {
+    "atmosphere": "neutral",
+    "events": [],
+}
+
+
+def react_to_emotion(input_emotion: str) -> Dict[str, Any]:
+    """Alter global ``state`` based on an emotion keyword."""
+    mood_map = {
+        "joy": "radiant",
+        "happy": "radiant",
+        "love": "radiant",
+        "anger": "stormy",
+        "fear": "tense",
+        "sad": "melancholic",
+    }
+    state["atmosphere"] = mood_map.get(input_emotion.lower(), "neutral")
+    return dict(state)
+
+
+def trigger_world_event(memory_trigger: str) -> Dict[str, Any]:
+    """Append a simple event derived from a memory trigger."""
+    event = f"Echo of {memory_trigger} reverberates"
+    state.setdefault("events", []).append(event)
+    return dict(state)
+
+
+def shift_world_state(agent_state: Dict[str, Any], environment: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge agent and environment information into the world ``state``."""
+    state.update(agent_state)
+    state.update(environment)
+    return dict(state)
+
+
+def simulate_consequence_pathways() -> Dict[str, Any]:
+    """Generate a placeholder consequence outcome."""
+    path = f"consequence_{len(state.get('events', []))}"
+    state["last_consequence"] = path
+    return dict(state)


### PR DESCRIPTION
## Summary
- add world state engine functions for emotion-driven mutation
- implement timeline branching and consequence orchestration modules
- expand dream world simulation with a reaction method
- document the new reactive world state utilities in README and manifesto

## Testing
- `python -m py_compile world_state_engine.py timeline_branching.py consequence_orchestrator.py dream_world_sim.py`

------
https://chatgpt.com/codex/tasks/task_e_685707bc4f1c832ebb85469f1d7d1438