### PR TITLE
Add perceptual loop and contextual response system

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ when one is not supplied. Inspect stored history or run a quick demo via:
 ```bash
 python controller.py --test-memory
 ```
+
+### Scene Context Manager
+
+The conversational agents can now draw on environmental cues using
+`SceneContextManager`. This layer tracks the time of day, emotional tone,
+and surroundings based on user input so responses feel more grounded in a
+dynamic world.

--- a/frontend_agent.py
+++ b/frontend_agent.py
@@ -7,6 +7,7 @@ from typing import Any, Dict
 from memory import MemoryManager
 from dream_world_sim import DreamWorldSim
 from guardian_protocols import GuardianProtocols
+from scene_context import SceneContextManager
 
 
 class EmotionEngine:
@@ -42,7 +43,9 @@ class QuantumLogicEngine:
 
     PATHS = ("symbolic", "chaotic", "emotional", "logical")
 
-    def process(self, text: str, emotion: Dict[str, Any], metadata: Dict[str, Any]) -> Dict[str, Any]:
+    def process(
+        self, text: str, emotion: Dict[str, Any], metadata: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """Select a reasoning path based on input emotion."""
         if emotion.get("polarity", 0) > 1:
             path = "logical"
@@ -62,24 +65,36 @@ class FrontendAgent:
         self.logic_engine = QuantumLogicEngine()
         self.dream_engine = DreamWorldSim()
         self.guardian = GuardianProtocols()
+        self.scene_manager = SceneContextManager()
 
-    def generate_response(self, text: str, logic: Dict[str, Any]) -> str:
-        """Return a rudimentary response based on the chosen logic path."""
+    def generate_response(
+        self, text: str, logic: Dict[str, Any], context: Dict[str, Any]
+    ) -> str:
+        """Return a rudimentary response using scene context."""
         path = logic.get("path")
         if path == "logical":
-            return f"Understood: {text}"
-        if path == "emotional":
-            return f"I sense strong feelings in: '{text}'"
-        if path == "symbolic":
-            return f"🔮 {text}"
-        if path == "chaotic":
-            return text[::-1]
-        return text
+            base = f"Understood: {text}"
+        elif path == "emotional":
+            base = f"I sense strong feelings in: '{text}'"
+        elif path == "symbolic":
+            base = f"🔮 {text}"
+        elif path == "chaotic":
+            base = text[::-1]
+        else:
+            base = text
+        return (
+            f"In this {context['emotion']} {context['time']} within "
+            f"{context['surroundings']}, {base}"
+        )
 
     async def handle(self, input_data: Dict[str, Any]) -> Dict[str, Any]:
         session_id = input_data.get("session_id") or uuid.uuid4().hex
         text = input_data.get("text", "")
-        metadata = {k: v for k, v in input_data.items() if k not in {"session_id", "text"}}
+        metadata = {
+            k: v
+            for k, v in input_data.items()
+            if k not in {"session_id", "text"}
+        }
 
         protection = self.guardian.evaluate(text)
         if protection["status"] == "neutralized":
@@ -89,7 +104,9 @@ class FrontendAgent:
 
         emotion = self.emotion_engine.analyze(text)
         logic = self.logic_engine.process(text, emotion, metadata)
-        response = self.generate_response(text, logic)
+        self.scene_manager.update_scene(text)
+        context = self.scene_manager.get_context()
+        response = self.generate_response(text, logic, context)
         dream = self.dream_engine.simulate(text)
 
         result = {
@@ -98,6 +115,7 @@ class FrontendAgent:
             "logic": logic,
             "dream": dream,
             "guardian": protection,
+            "context": context,
             "response": response,
         }
 

--- a/guardian_protocols.py
+++ b/guardian_protocols.py
@@ -7,5 +7,8 @@ class GuardianProtocols:
         """Return a protection status and message."""
         lowered = text.lower()
         if any(word in lowered for word in self.NEGATIVE_KEYWORDS):
-            return {"status": "neutralized", "message": "Neutralized threat, standing down."}
+            return {
+                "status": "neutralized",
+                "message": "Neutralized threat, standing down.",
+            }
         return {"status": "clear", "message": "All clear."}

--- a/memory.py
+++ b/memory.py
@@ -25,9 +25,14 @@ class Memory:
         )
         self.conn.commit()
 
-    def record(self, agent: str, input_data: Dict[str, Any], output: Any) -> None:
+    def record(
+        self, agent: str, input_data: Dict[str, Any], output: Any
+    ) -> None:
         self.conn.execute(
-            "INSERT INTO history (timestamp, agent, input, output) VALUES (?,?,?,?)",
+            (
+                "INSERT INTO history (timestamp, agent, input, output) "
+                "VALUES (?, ?, ?, ?)"
+            ),
             (
                 datetime.utcnow().isoformat(),
                 agent,
@@ -39,7 +44,8 @@ class Memory:
 
     def fetch_all(self) -> List[Tuple[str, str, str, str]]:
         cur = self.conn.execute(
-            "SELECT timestamp, agent, input, output FROM history ORDER BY id DESC"
+            "SELECT timestamp, agent, input, output "
+            "FROM history ORDER BY id DESC"
         )
         return cur.fetchall()
 
@@ -64,7 +70,9 @@ class MemoryManager:
             self.path.write_text("{}", encoding="utf-8")
 
     def _persist(self) -> None:
-        self.path.write_text(json.dumps(self.store, indent=2), encoding="utf-8")
+        self.path.write_text(
+            json.dumps(self.store, indent=2), encoding="utf-8"
+        )
 
     def log(self, session_id: str, user_input: Any, response: Any) -> None:
         """Append a conversation turn to a session."""
@@ -83,4 +91,3 @@ class MemoryManager:
     def fetch_all(self) -> Dict[str, List[Dict[str, Any]]]:
         """Return the entire memory store."""
         return self.store
-

--- a/scene_context.py
+++ b/scene_context.py
@@ -1,0 +1,39 @@
+class SceneContextManager:
+    """Manage time, emotional atmosphere, and surroundings for the agent."""
+
+    def __init__(self) -> None:
+        self.current_scene = {
+            "time": "dusk",
+            "emotion": "curious",
+            "surroundings": "twilight forest",
+        }
+
+    def update_scene(self, input_data: str) -> None:
+        """Update scene details based on the latest user input."""
+        lowered = input_data.lower()
+
+        # Determine time of day
+        if any(word in lowered for word in ("dawn", "morning", "sunrise")):
+            self.current_scene["time"] = "dawn"
+        elif any(word in lowered for word in ("noon", "afternoon")):
+            self.current_scene["time"] = "afternoon"
+        elif any(word in lowered for word in ("evening", "night", "dusk")):
+            self.current_scene["time"] = "night"
+
+        # Determine surroundings
+        if any(word in lowered for word in ("cold", "snow", "ice")):
+            self.current_scene["surroundings"] = "frozen temple"
+        elif "rain" in lowered:
+            self.current_scene["surroundings"] = "rain-soaked streets"
+        elif "forest" in lowered:
+            self.current_scene["surroundings"] = "twilight forest"
+
+        # Determine emotional atmosphere
+        if "love" in lowered:
+            self.current_scene["emotion"] = "enchanted"
+        elif any(word in lowered for word in ("fear", "worry")):
+            self.current_scene["emotion"] = "tense"
+
+    def get_context(self) -> dict:
+        """Return a copy of the current scene context."""
+        return dict(self.current_scene)


### PR DESCRIPTION
## Summary
- add `SceneContextManager` for scene-based contextual data
- integrate scene context into `FrontendAgent` responses
- fix code style issues and ensure linter clean
- document scene context layer in README

## Testing
- `python -m py_compile scene_context.py frontend_agent.py dream_world_sim.py guardian_protocols.py memory.py`
- `flake8 frontend_agent.py scene_context.py dream_world_sim.py guardian_protocols.py memory.py`


------
https://chatgpt.com/codex/tasks/task_e_6856eda58e94832e9b763bbcbb71c5fb