### PR TITLE
Add WraithForge AI demo modules

### DIFF
--- a/core.py
+++ b/core.py
@@ -1,0 +1,18 @@
+class WraithForgeCore:
+    def __init__(self):
+        self.modules = {}
+        self.active = False
+
+    def activate(self):
+        self.active = True
+        print("🗡️ WraithForge AI online. Ready to engage offensive protocols.")
+
+    def load_module(self, name, function):
+        self.modules[name] = function
+        print(f"⚙️ Module '{name}' loaded.")
+
+    def run_module(self, name, *args):
+        if name in self.modules:
+            return self.modules[name](*args)
+        else:
+            return "❌ Module not found."

--- a/modules/amplify.py
+++ b/modules/amplify.py
@@ -1,0 +1,5 @@
+def amplify_spell(spell_fn):
+    def wrapper(target):
+        result = spell_fn(target)
+        return result + " ✨ Spell amplified by WraithForge Core."
+    return wrapper

--- a/modules/fire.py
+++ b/modules/fire.py
@@ -1,0 +1,2 @@
+def pyro_pulse(target):
+    return f"🔥 PyroPulse launched at {target}! Engulfed in burning flames."

--- a/modules/ice.py
+++ b/modules/ice.py
@@ -1,0 +1,2 @@
+def cryo_breach(target):
+    return f"❄️ CryoBreach strikes {target}! Temperature plummeting. Movement frozen."

--- a/modules/mind.py
+++ b/modules/mind.py
@@ -1,0 +1,2 @@
+def neuro_disturb(target):
+    return f"🌀 NeuroDisturb activated on {target}. Neural confusion engaged."

--- a/run_demo.py
+++ b/run_demo.py
@@ -1,0 +1,20 @@
+from core import WraithForgeCore
+from modules.fire import pyro_pulse
+from modules.ice import cryo_breach
+from modules.mind import neuro_disturb
+from modules.amplify import amplify_spell
+
+# Optional: Amplify spells
+pyro_pulse = amplify_spell(pyro_pulse)
+cryo_breach = amplify_spell(cryo_breach)
+
+wf = WraithForgeCore()
+wf.activate()
+
+wf.load_module("fire", pyro_pulse)
+wf.load_module("ice", cryo_breach)
+wf.load_module("mind", neuro_disturb)
+
+print(wf.run_module("fire", "Shadow Entity"))
+print(wf.run_module("ice", "Hostile Area"))
+print(wf.run_module("mind", "Enemy AI"))


### PR DESCRIPTION
## Summary
- add `core.py` with WraithForgeCore class
- add spell modules: fire, ice, mind and an amplifier
- provide a `run_demo.py` sample usage script

## Testing
- `pytest -q`
- `python run_demo.py`


------
https://chatgpt.com/codex/tasks/task_e_685764c2fcf0832e9582f755fd80e745