### PR TITLE
Resolve scene context import conflicts

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -6,7 +6,7 @@ from .retail_agent import RetailAgent
 from .healthcare_agent import HealthcareAgent
 from .real_estate_agent import RealEstateAgent
 from .pricing_agent import PricingAgent
-from .scene_context import SceneContextManager  # noqa: F401
+from agents.scene_context import SceneContextManager  # noqa: F401
 
 __all__ = [
     "FinanceAgent",

--- a/agents/frontend_agent.py
+++ b/agents/frontend_agent.py
@@ -7,11 +7,7 @@ from typing import Any, Dict, Optional
 from memory import MemoryManager
 from dream_world_sim import DreamWorldSim
 from guardian_protocols import GuardianProtocols
-
-try:
-    from .scene_context import SceneContextManager
-except ImportError:  # pragma: no cover - fallback for direct execution
-    from scene_context import SceneContextManager
+from agents.scene_context import SceneContextManager
 
 
 class EmotionEngine:


### PR DESCRIPTION
## Summary
- fix `SceneContextManager` imports to use `agents.scene_context`
- export `SceneContextManager` from agents package

## Testing
- `npm i -w apps/companion_api -w apps/companion_web`
- `npm --workspace apps/companion_api run build`
- `npm --workspace apps/companion_web run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68992db7f748832e9b8422accb973bc4