### PR TITLE
chore: trigger Vercel deploy

### DIFF
--- a/deploy.log
+++ b/deploy.log
@@ -1,0 +1,1 @@
+Deploy trigger Mon Aug 11 17:44:24 UTC 2025


### PR DESCRIPTION
## Summary
- trigger Vercel deployment by appending timestamp to `deploy.log`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a2b6e8744832eaa78847d5f8fe875