### PR TITLE
feat(web): add /api/lyra endpoint for AI replies

### DIFF
--- a/apps/companion_web/pages/api/lyra.ts
+++ b/apps/companion_web/pages/api/lyra.ts
@@ -1,0 +1,46 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
+  try {
+    const { message, mode = 'chill' } = (req.body ?? {}) as { message?: string; mode?: string };
+
+    if (!message || typeof message !== 'string') {
+      return res.status(400).json({ error: 'Missing "message" in body' });
+    }
+
+    if (!process.env.OPENAI_API_KEY) {
+      return res.status(200).json({ reply: `(demo:${mode}) ${message}` });
+    }
+
+    const r = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: `You are Lyra, a ${mode} assistant.` },
+          { role: 'user', content: message },
+        ],
+      }),
+    });
+
+    if (!r.ok) {
+      const errText = await r.text();
+      console.error('[lyra] openai error:', errText);
+      return res.status(500).json({ error: 'OpenAI request failed' });
+    }
+
+    const data = await r.json();
+    const reply = data?.choices?.[0]?.message?.content?.trim() || '';
+    return res.status(200).json({ reply: reply || '[No response from AI]' });
+  } catch (err) {
+    console.error('[lyra] error:', err);
+    return res.status(500).json({ error: 'Server error' });
+  }
+}
+

--- a/apps/companion_web/pages/index.tsx
+++ b/apps/companion_web/pages/index.tsx
@@ -15,12 +15,16 @@ export default function Home() {
     setInput(''); setBusy(true);
     setMessages(m => [...m, { role:'you', text }]);
     try {
-      const r = await fetch('/api/chat', {
+      const resp = await fetch('/api/lyra', {
         method: 'POST',
-        headers: { 'Content-Type':'application/json' },
-        body: JSON.stringify({ message: text, mode })
-      }).then(r=>r.json());
-      setMessages(m => [...m, { role:'lyra', text: r.reply || '(no reply)' }]);
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text, mode }),
+      });
+      const { reply } = await resp.json();
+      setMessages(m => [...m, { role: 'lyra', text: reply || '(no reply)' }]);
+    } catch (e) {
+      console.error('send error', e);
+      setMessages(m => [...m, { role: 'lyra', text: '(error sending message)' }]);
     } finally { setBusy(false); }
   }
 


### PR DESCRIPTION
## Summary
- add Lyra API route using OpenAI Chat Completions and env OPENAI_API_KEY
- update web chat page to post messages to new endpoint with error handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --workspace apps/companion_web run build`


------
https://chatgpt.com/codex/tasks/task_e_689a3b488a50832e87eba87f06bcbae7