### PR TITLE
feat(legal): internal legal agent (research + draft) with guardrails

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -154,3 +154,30 @@ npm run dev   # if frontend present
 - Memory persistence across sessions
 
 ---
+
+## 13. Legal Agent (Internal Use)
+
+**Endpoints**
+- `POST /api/legal/research` – internal legal research with web citations
+- `POST /api/legal/draft` – generate draft docs from templates
+
+**Headers**
+- `x-user-role`: must be one of `staff` or `firm_user`
+
+**Examples**
+```bash
+curl -X POST https://<site>/api/legal/research \
+  -H "Content-Type: application/json" \
+  -H "x-user-role: staff" \
+  -d '{"query":"California non-compete enforceability 2025 updates","jurisdiction":"US-CA"}'
+
+curl -X POST https://<site>/api/legal/draft \
+  -H "Content-Type: application/json" \
+  -H "x-user-role: firm_user" \
+  -d '{"type":"NDA_basic","facts":{"PartyA":"Acme LLC","PartyB":"Ricky Castrejon","EffectiveDate":"2025-08-15"},"jurisdiction":"US-CA"}'
+```
+
+Requests without an allowed role are refused.
+
+**Disclaimer**
+> ⚠️ Not legal advice. For attorney review.

--- a/apps/companion_web/components/LegalNotice.tsx
+++ b/apps/companion_web/components/LegalNotice.tsx
@@ -1,0 +1,18 @@
+import { banner } from '../server/legal/guardrails';
+
+export default function LegalNotice() {
+  return (
+    <div className="legal-notice">
+      {banner}
+      <style jsx>{`
+        .legal-notice {
+          border: 1px solid #facc15;
+          background: #fef3c7;
+          padding: 8px;
+          color: #92400e;
+          margin-bottom: 1rem;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/companion_web/pages/api/legal/_common.ts
+++ b/apps/companion_web/pages/api/legal/_common.ts
@@ -1,0 +1,57 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export function roleFrom(req: NextApiRequest): string {
+  return (req.headers['x-user-role'] as string) || 'guest';
+}
+
+export async function tavilySearch(query: string) {
+  const r = await fetch('https://api.tavily.com/search', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.TAVILY_API_KEY}`
+    },
+    body: JSON.stringify({ query, include_answer: true, max_results: 6 })
+  }).then(r => r.json());
+  return {
+    answer: r?.answer || '',
+    results: (r?.results || []).map((x: any) => ({ title: x.title, url: x.url, snippet: x.snippet }))
+  };
+}
+
+export async function openaiSummarize(prompt: string) {
+  const r = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: prompt }],
+      temperature: 0.2
+    })
+  }).then(r => r.json());
+  return r?.choices?.[0]?.message?.content || '';
+}
+
+export function limitGate(req: NextApiRequest, res: NextApiResponse) {
+  const max = parseInt(process.env.LEGAL_DAILY_LIMIT || '200', 10);
+  const cookieName = 'legal_daily';
+  const now = Date.now();
+  const cookie = req.cookies?.[cookieName] || '';
+  const [countStr, resetStr] = cookie.split('|');
+  let count = parseInt(countStr) || 0;
+  let reset = resetStr ? new Date(resetStr).getTime() : 0;
+  if (!resetStr || reset <= now) {
+    count = 0;
+    const d = new Date();
+    d.setUTCHours(24, 0, 0, 0);
+    reset = d.getTime();
+  }
+  const ok = count < max;
+  if (ok) count += 1;
+  const setCookie = `${cookieName}=${count}|${new Date(reset).toISOString()}; Path=/; HttpOnly; SameSite=Lax;`;
+  const remaining = ok ? max - count : 0;
+  return { ok, setCookie, remaining, resetISO: new Date(reset).toISOString() };
+}

--- a/apps/companion_web/pages/api/legal/draft.ts
+++ b/apps/companion_web/pages/api/legal/draft.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { roleFrom, limitGate } from './_common';
+import { isAllowed, banner, requireJurisdiction, redact } from '../../../server/legal/guardrails';
+import fs from 'fs';
+import path from 'path';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+  const role = roleFrom(req);
+  if (!isAllowed(role)) {
+    return res.status(403).json({ error: 'unauthorized', message: 'For internal use only.' });
+  }
+  const { type, facts = {}, jurisdiction } = (req.body as any) || {};
+  if (!type) return res.status(400).json({ error: 'type_required' });
+  const { juris } = requireJurisdiction(jurisdiction);
+  const gate = limitGate(req, res);
+  res.setHeader('Set-Cookie', gate.setCookie);
+  if (!gate.ok) {
+    return res.status(402).json({ error: 'limit_reached', upgrade: process.env.BILLING_URL || null });
+  }
+  const tplPath = path.join(process.cwd(), 'server', 'legal', 'templates', `${type}.md`);
+  if (!fs.existsSync(tplPath)) return res.status(400).json({ error: 'unknown_template' });
+  let template = fs.readFileSync(tplPath, 'utf8');
+  const placeholders = Array.from(template.matchAll(/{{(.*?)}}/g)).map(m => m[1]);
+  const checklist: string[] = [];
+  const allFacts: Record<string, string> = { ...facts, Jurisdiction: facts.Jurisdiction || juris };
+  placeholders.forEach(key => {
+    if (allFacts[key]) {
+      template = template.replace(new RegExp(`{{${key}}}`, 'g'), allFacts[key]);
+    } else {
+      template = template.replace(new RegExp(`{{${key}}}`, 'g'), '[[BLANK]]');
+      checklist.push(`Fill ${key}`);
+    }
+  });
+  const draft = `${banner} Draft — Attorney Review Required\n\n${template}`;
+  console.log('[LEGAL_AUDIT] draft', redact(JSON.stringify({ type, role })));
+  return res.status(200).json({ draft, checklist });
+}

--- a/apps/companion_web/pages/api/legal/research.ts
+++ b/apps/companion_web/pages/api/legal/research.ts
@@ -1,0 +1,28 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { roleFrom, tavilySearch, openaiSummarize, limitGate } from './_common';
+import { isAllowed, banner, requireJurisdiction, shouldRefuse, redact } from '../../../server/legal/guardrails';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') return res.status(405).json({ error: 'method_not_allowed' });
+  const role = roleFrom(req);
+  if (!isAllowed(role)) {
+    return res.status(403).json({ error: 'unauthorized', message: 'For internal use only.' });
+  }
+  const { query, jurisdiction, intent = 'research' } = (req.body as any) || {};
+  if (!query || typeof query !== 'string') return res.status(400).json({ error: 'query_required' });
+  if (shouldRefuse(intent, role)) return res.status(403).json({ error: 'unauthorized' });
+  const { juris, note } = requireJurisdiction(jurisdiction);
+  const gate = limitGate(req, res);
+  res.setHeader('Set-Cookie', gate.setCookie);
+  if (!gate.ok) {
+    return res.status(402).json({ error: 'limit_reached', upgrade: process.env.BILLING_URL || null });
+  }
+  const search = await tavilySearch(query);
+  const prompt = `Summarize the following legal research for jurisdiction ${juris} with numbered citations like [1].\n` +
+    search.results.map((r: any, i: number) => `[${i + 1}] ${r.title} - ${r.snippet}`).join('\n');
+  const body = await openaiSummarize(prompt);
+  const summary = `${banner}\n${note}\n\n${body}`;
+  const citations = search.results.map((r: any) => ({ title: r.title, url: r.url }));
+  console.log('[LEGAL_AUDIT] research', redact(JSON.stringify({ query, role })));
+  return res.status(200).json({ summary, citations });
+}

--- a/apps/companion_web/server/legal/guardrails.ts
+++ b/apps/companion_web/server/legal/guardrails.ts
@@ -1,0 +1,26 @@
+export function allowedRoles(): string[] {
+  return (process.env.LEGAL_ALLOWED_ROLES || 'staff,firm_user').split(',').map(r => r.trim());
+}
+
+export function isAllowed(role: string): boolean {
+  return allowedRoles().includes(role);
+}
+
+export const banner = '⚠️ Not legal advice. For attorney review.';
+
+export function requireJurisdiction(j?: string): { juris: string; note: string } {
+  const juris = j || process.env.LEGAL_DEFAULT_JURISDICTION || 'US';
+  return { juris, note: `Jurisdiction: ${juris}` };
+}
+
+export function shouldRefuse(intent: string, role: string): boolean {
+  if (!isAllowed(role)) return true;
+  return intent !== 'research';
+}
+
+export function redact(str: string): string {
+  return str
+    .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, '[redacted]')
+    .replace(/sk-[A-Za-z0-9]{10,}/g, '[redacted]')
+    .replace(/tvly-[A-Za-z0-9]{10,}/g, '[redacted]');
+}

--- a/apps/companion_web/server/legal/templates/Demand_Letter.md
+++ b/apps/companion_web/server/legal/templates/Demand_Letter.md
@@ -1,0 +1,12 @@
+# Demand Letter
+
+Date: {{EffectiveDate}}
+
+To: {{Recipient}}
+From: {{Sender}}
+
+We demand {{Demand}} within {{Jurisdiction}}.
+
+Sincerely,
+
+{{Sender}}

--- a/apps/companion_web/server/legal/templates/Engagement_Letter.md
+++ b/apps/companion_web/server/legal/templates/Engagement_Letter.md
@@ -1,0 +1,12 @@
+# Engagement Letter
+
+Date: {{EffectiveDate}}
+
+{{FirmName}} agrees to represent {{ClientName}} in {{Jurisdiction}}.
+
+Scope of work: {{Scope}}
+Fees: {{Fees}}
+
+Sincerely,
+
+{{FirmName}}

--- a/apps/companion_web/server/legal/templates/NDA_basic.md
+++ b/apps/companion_web/server/legal/templates/NDA_basic.md
@@ -1,0 +1,12 @@
+# Mutual Non-Disclosure Agreement
+
+This Mutual Non-Disclosure Agreement ("Agreement") is made effective as of {{EffectiveDate}} 
+between {{PartyA}} and {{PartyB}} in {{Jurisdiction}}.
+
+1. The Parties agree to keep all confidential information private.
+2. This Agreement remains in effect for two (2) years from the Effective Date.
+
+Signed,
+
+- {{PartyA}}
+- {{PartyB}}


### PR DESCRIPTION
## Summary
- add server guardrails for allowed roles, jurisdiction checks, redaction utilities
- implement legal research & drafting API endpoints with rate limiting and audit logs
- include markdown templates, UI notice component, and codex documentation for internal legal agent

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --workspace apps/companion_web run build`


------
https://chatgpt.com/codex/tasks/task_e_689a55c31578832e87eeebbbdafa042e