### PR TITLE
Ensure Lyra responds even on failures

### DIFF
--- a/apps/companion_web/pages/api/lyra.ts
+++ b/apps/companion_web/pages/api/lyra.ts
@@ -32,15 +32,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (!r.ok) {
       const errText = await r.text();
       console.error('[lyra] openai error:', errText);
-      return res.status(500).json({ error: 'OpenAI request failed' });
+      return res
+        .status(500)
+        .json({ error: "Sorry, I'm having trouble responding right now." });
     }
 
     const data = await r.json();
-    const reply = data?.choices?.[0]?.message?.content?.trim() || '';
-    return res.status(200).json({ reply: reply || '[No response from AI]' });
+    const reply = data?.choices?.[0]?.message?.content?.trim();
+    return res
+      .status(200)
+      .json({ reply: reply ?? "I'm not sure what to say, but I'm here!" });
   } catch (err) {
     console.error('[lyra] error:', err);
-    return res.status(500).json({ error: 'Server error' });
+    return res
+      .status(500)
+      .json({ error: "I'm having trouble replying right now." });
   }
 }
 

--- a/apps/companion_web/pages/index.tsx
+++ b/apps/companion_web/pages/index.tsx
@@ -20,8 +20,9 @@ export default function Home() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ message: text, mode }),
       });
-      const { reply } = await resp.json();
-      setMessages(m => [...m, { role: 'lyra', text: reply || '(no reply)' }]);
+      const data = (await resp.json()) as { reply?: string; error?: string };
+      const textReply = data.reply ?? data.error ?? 'I had trouble replying.';
+      setMessages(m => [...m, { role: 'lyra', text: textReply }]);
     } catch (e) {
       console.error('send error', e);
       setMessages(m => [...m, { role: 'lyra', text: '(error sending message)' }]);


### PR DESCRIPTION
## Summary
- Provide friendly fallback replies from Lyra API when OpenAI or server errors occur
- Display API reply or error on the client so users never see a blank '(no reply)'

## Testing
- `pytest`
- `npm --workspace apps/companion_web run build`


------
https://chatgpt.com/codex/tasks/task_e_689a510211f8832e8acda1929f341055