### PR TITLE
feat(companion): cute checkups + state-aware safety

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -181,3 +181,23 @@ Requests without an allowed role are refused.
 
 **Disclaimer**
 > ⚠️ Not legal advice. For attorney review.
+
+---
+
+## Companion Checkups
+
+Periodic mental wellness pings with safety guidance.
+
+**API:**
+- `GET /api/companion/checkups` – fetch user preferences
+- `POST /api/companion/checkups` – save preferences `{ tone, daily, email }`
+- `PUT /api/companion/checkups` – send a check-in immediately (uses `x-user-id` and `x-jurisdiction` headers). Always appends the `988/911` safety footer and gates therapy mode according to `server/compliance/state_policies.json`.
+
+**Admin:**
+- `/admin/companion/checkups?key=<NEXT_PUBLIC_ADMIN_UI_KEY>` – select tone, preview message, or trigger an immediate checkup.
+
+**Cron Job:**
+- `POST /api/jobs/checkups/daily` with header `x-admin-key` sends daily check-ins to all opted-in users. Intended to run Mon–Fri 9:00 AM America/Chicago.
+
+**Compliance:**
+If `state_policies.json` marks a jurisdiction as therapy-restricted, requests for therapy mode are downgraded to `friend+journal` mode.

--- a/apps/companion_web/components/CompanionCheckupsPanel.tsx
+++ b/apps/companion_web/components/CompanionCheckupsPanel.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+
+export default function CompanionCheckupsPanel() {
+  const [tone, setTone] = useState('kind');
+  const [daily, setDaily] = useState(false);
+  const [email, setEmail] = useState('');
+  const [last, setLast] = useState('');
+
+  useEffect(() => {
+    fetch('/api/companion/checkups', { headers: { 'x-user-id': 'demo' } })
+      .then(r => r.json())
+      .then(d => {
+        if (d.tone) setTone(d.tone);
+        if (d.daily) setDaily(d.daily);
+        if (d.email) setEmail(d.email);
+      });
+  }, []);
+
+  async function save() {
+    await fetch('/api/companion/checkups', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-user-id': 'demo' },
+      body: JSON.stringify({ tone, daily, email })
+    });
+  }
+
+  async function sendNow() {
+    const resp = await fetch('/api/companion/checkups?preview=1', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'x-user-id': 'demo', 'x-jurisdiction': 'US-CA' },
+      body: JSON.stringify({ tone })
+    });
+    const data = await resp.json();
+    setLast(data.message);
+  }
+
+  return (
+    <div style={{border:'1px solid #223',padding:12,borderRadius:8}}>
+      <h3 style={{marginTop:0}}>Companion Checkups</h3>
+      <div style={{marginBottom:8}}>
+        <label>Tone:</label>
+        <select value={tone} onChange={e=>setTone(e.target.value)} style={{marginLeft:4}}>
+          <option value="kind">kind</option>
+          <option value="playful">playful</option>
+          <option value="professional">professional</option>
+        </select>
+      </div>
+      <div style={{marginBottom:8}}>
+        <label>
+          <input type="checkbox" checked={daily} onChange={e=>setDaily(e.target.checked)} /> Daily check-in
+        </label>
+      </div>
+      <div style={{marginBottom:8}}>
+        <input value={email} onChange={e=>setEmail(e.target.value)} placeholder="email" style={{width:'100%'}} />
+      </div>
+      <div style={{display:'flex',gap:8}}>
+        <button onClick={save}>Save</button>
+        <button onClick={sendNow}>Send now</button>
+      </div>
+      {last && <div style={{marginTop:8,opacity:.7,whiteSpace:'pre-wrap'}}>{last}</div>}
+    </div>
+  );
+}

--- a/apps/companion_web/pages/admin/companion/checkups.tsx
+++ b/apps/companion_web/pages/admin/companion/checkups.tsx
@@ -1,0 +1,50 @@
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+
+const ADMIN_KEY = process.env.NEXT_PUBLIC_ADMIN_UI_KEY;
+
+export default function CheckupsAdmin() {
+  const router = useRouter();
+  const { key } = router.query;
+  const [tone, setTone] = useState('kind');
+  const [preview, setPreview] = useState('');
+
+  if (ADMIN_KEY && key !== ADMIN_KEY) {
+    return <div>Forbidden</div>;
+  }
+
+  async function doPreview() {
+    const resp = await fetch(`/api/companion/checkups?preview=1`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'x-user-id': 'demo', 'x-jurisdiction': 'US' },
+      body: JSON.stringify({ tone })
+    });
+    const data = await resp.json();
+    setPreview(data.message);
+  }
+
+  async function trigger() {
+    await fetch(`/api/companion/checkups`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json', 'x-user-id': 'demo', 'x-jurisdiction': 'US' },
+      body: JSON.stringify({ tone })
+    });
+  }
+
+  return (
+    <div style={{padding:20}}>
+      <h1>Companion Checkups</h1>
+      <label>Tone: </label>
+      <select value={tone} onChange={e=>setTone(e.target.value)}>
+        <option value="kind">kind</option>
+        <option value="playful">playful</option>
+        <option value="professional">professional</option>
+      </select>
+      <div style={{marginTop:12}}>
+        <button onClick={doPreview}>Preview message</button>
+        <button onClick={trigger} style={{marginLeft:8}}>Send now</button>
+      </div>
+      {preview && <pre style={{marginTop:16,whiteSpace:'pre-wrap'}}>{preview}</pre>}
+    </div>
+  );
+}

--- a/apps/companion_web/pages/api/companion/checkups.ts
+++ b/apps/companion_web/pages/api/companion/checkups.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getPrefs, savePrefs, addMessage, CheckupPrefs } from '../../../server/companion/checkupsStore';
+import { buildMessage } from '../../../server/companion/messages';
+import { gateCompanionMode } from '../../../server/compliance/check';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const userId = req.headers['x-user-id'] as string | undefined;
+  if (!userId) return res.status(400).json({ error: 'missing user id' });
+
+  if (req.method === 'GET') {
+    const prefs = await getPrefs(userId);
+    return res.status(200).json(prefs || {});
+  }
+
+  if (req.method === 'POST') {
+    const body = req.body as CheckupPrefs;
+    await savePrefs(userId, body);
+    return res.status(200).json({ ok: true });
+  }
+
+  if (req.method === 'PUT') {
+    const tone = (req.body && req.body.tone) || 'kind';
+    const jurisdiction = (req.headers['x-jurisdiction'] as string) || 'US';
+    const mode = gateCompanionMode('therapy', jurisdiction);
+    const message = buildMessage(tone, mode);
+    if (!('preview' in req.query)) {
+      await addMessage(userId, message);
+    }
+    return res.status(200).json({ sent: !('preview' in req.query), mode, message });
+  }
+
+  res.setHeader('Allow', ['GET', 'POST', 'PUT']);
+  return res.status(405).end();
+}

--- a/apps/companion_web/pages/api/jobs/checkups/daily.ts
+++ b/apps/companion_web/pages/api/jobs/checkups/daily.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { allUsers, addMessage } from '../../../../server/companion/checkupsStore';
+import { buildMessage } from '../../../../server/companion/messages';
+import { gateCompanionMode } from '../../../../server/compliance/check';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.headers['x-admin-key'] !== process.env.ADMIN_DASH_KEY) {
+    return res.status(401).json({ error: 'unauthorized' });
+  }
+  const store = await allUsers();
+  let sent = 0;
+  for (const [userId, rec] of Object.entries(store)) {
+    if (rec.prefs.daily) {
+      const mode = gateCompanionMode('therapy', rec.prefs.jurisdiction || 'US');
+      const msg = buildMessage(rec.prefs.tone, mode);
+      await addMessage(userId, msg);
+      sent++;
+    }
+  }
+  res.status(200).json({ sent });
+}

--- a/apps/companion_web/pages/index.tsx
+++ b/apps/companion_web/pages/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import CompanionCheckupsPanel from '../components/CompanionCheckupsPanel';
 
 const MODES = ['chill','sassy','sage','gremlin'] as const;
 type Mode = typeof MODES[number];
@@ -30,43 +31,48 @@ export default function Home() {
   }
 
   return (
-    <div style={{minHeight:'100vh',background:'#0b0f16',color:'#e6f1ff',padding:'24px',maxWidth:780,margin:'0 auto'}}>
-      <h1 style={{fontSize:28,marginBottom:6}}>AITaskFlo</h1>
-      <div style={{opacity:.7,marginBottom:16}}>Your personality-driven AI console.</div>
+    <div style={{minHeight:'100vh',background:'#0b0f16',color:'#e6f1ff',padding:'24px',display:'flex',gap:24}}>
+      <div style={{flex:1,maxWidth:780}}>
+        <h1 style={{fontSize:28,marginBottom:6}}>AITaskFlo</h1>
+        <div style={{opacity:.7,marginBottom:16}}>Your personality-driven AI console.</div>
 
-      <div style={{display:'flex',gap:8,flexWrap:'wrap',marginBottom:16}}>
-        {MODES.map(m => (
-          <button key={m} onClick={()=>setMode(m)}
-            style={{ padding:'8px 12px', borderRadius:10, border:'1px solid #223',
-                     background: m===mode ? 'linear-gradient(90deg,#6ee7,#8af)' : '#121826',
-                     color: m===mode ? '#001' : '#e6f1ff' }}>
-            {m}
+        <div style={{display:'flex',gap:8,flexWrap:'wrap',marginBottom:16}}>
+          {MODES.map(m => (
+            <button key={m} onClick={()=>setMode(m)}
+              style={{ padding:'8px 12px', borderRadius:10, border:'1px solid #223',
+                       background: m===mode ? 'linear-gradient(90deg,#6ee7,#8af)' : '#121826',
+                       color: m===mode ? '#001' : '#e6f1ff' }}>
+              {m}
+            </button>
+          ))}
+        </div>
+
+        <div style={{border:'1px solid #223',borderRadius:12,padding:12,minHeight:320,background:'#0e1422'}}>
+          {messages.length===0 && <div style={{opacity:.6}}>Say hi and I’ll reply…</div>}
+          {messages.map((m,i)=>(
+            <div key={i} style={{margin:'10px 0'}}>
+              <b style={{color:m.role==='you'?'#9ff':'#9f9'}}>{m.role==='you'?'You':'Lyra'}</b>: {m.text}
+            </div>
+          ))}
+          {busy && <div style={{opacity:.6,marginTop:8}}>Lyra is typing…</div>}
+        </div>
+
+        <div style={{display:'flex',gap:8,marginTop:12}}>
+          <input
+            value={input}
+            onChange={e=>setInput(e.target.value)}
+            onKeyDown={e=>e.key==='Enter' && send()}
+            placeholder="Type a message…"
+            style={{flex:1,padding:'10px 12px',borderRadius:10,border:'1px solid #223',background:'#0e1422',color:'#e6f1ff'}}
+          />
+          <button onClick={send} disabled={busy}
+            style={{padding:'10px 16px',borderRadius:10,background:'linear-gradient(90deg,#6ee7,#8af)',border:'none',color:'#001'}}>
+            Send
           </button>
-        ))}
+        </div>
       </div>
-
-      <div style={{border:'1px solid #223',borderRadius:12,padding:12,minHeight:320,background:'#0e1422'}}>
-        {messages.length===0 && <div style={{opacity:.6}}>Say hi and I’ll reply…</div>}
-        {messages.map((m,i)=>(
-          <div key={i} style={{margin:'10px 0'}}>
-            <b style={{color:m.role==='you'?'#9ff':'#9f9'}}>{m.role==='you'?'You':'Lyra'}</b>: {m.text}
-          </div>
-        ))}
-        {busy && <div style={{opacity:.6,marginTop:8}}>Lyra is typing…</div>}
-      </div>
-
-      <div style={{display:'flex',gap:8,marginTop:12}}>
-        <input
-          value={input}
-          onChange={e=>setInput(e.target.value)}
-          onKeyDown={e=>e.key==='Enter' && send()}
-          placeholder="Type a message…"
-          style={{flex:1,padding:'10px 12px',borderRadius:10,border:'1px solid #223',background:'#0e1422',color:'#e6f1ff'}}
-        />
-        <button onClick={send} disabled={busy}
-          style={{padding:'10px 16px',borderRadius:10,background:'linear-gradient(90deg,#6ee7,#8af)',border:'none',color:'#001'}}>
-          Send
-        </button>
+      <div style={{width:260}}>
+        <CompanionCheckupsPanel />
       </div>
     </div>
   );

--- a/apps/companion_web/server/companion/checkupsStore.ts
+++ b/apps/companion_web/server/companion/checkupsStore.ts
@@ -1,0 +1,54 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export interface CheckupPrefs {
+  tone: string;
+  daily: boolean;
+  email?: string;
+  jurisdiction?: string;
+}
+
+interface StoreRecord {
+  prefs: CheckupPrefs;
+  messages: { text: string; timestamp: number }[];
+}
+
+const DATA_FILE = path.join(process.cwd(), 'checkupsStore.json');
+
+async function readStore(): Promise<Record<string, StoreRecord>> {
+  try {
+    const data = await fs.readFile(DATA_FILE, 'utf8');
+    return JSON.parse(data) as Record<string, StoreRecord>;
+  } catch {
+    return {};
+  }
+}
+
+async function writeStore(store: Record<string, StoreRecord>): Promise<void> {
+  await fs.writeFile(DATA_FILE, JSON.stringify(store, null, 2), 'utf8');
+}
+
+export async function getPrefs(userId: string): Promise<CheckupPrefs | null> {
+  const store = await readStore();
+  return store[userId]?.prefs || null;
+}
+
+export async function savePrefs(userId: string, prefs: CheckupPrefs): Promise<void> {
+  const store = await readStore();
+  const rec = store[userId] || { prefs, messages: [] };
+  rec.prefs = prefs;
+  store[userId] = rec;
+  await writeStore(store);
+}
+
+export async function addMessage(userId: string, text: string): Promise<void> {
+  const store = await readStore();
+  const rec = store[userId] || { prefs: { tone: 'kind', daily: false }, messages: [] };
+  rec.messages.push({ text, timestamp: Date.now() });
+  store[userId] = rec;
+  await writeStore(store);
+}
+
+export async function allUsers(): Promise<Record<string, StoreRecord>> {
+  return await readStore();
+}

--- a/apps/companion_web/server/companion/messages.ts
+++ b/apps/companion_web/server/companion/messages.ts
@@ -1,0 +1,12 @@
+export const tones: Record<string, string> = {
+  kind: "Just checking in—how are you feeling today?",
+  playful: "Hey friend! Time for a quick self check-in.",
+  professional: "Hello, this is a friendly reminder to take a moment for yourself.",
+};
+
+export const safetyFooter = "If you're in crisis, call 911 or text 988 for support.";
+
+export function buildMessage(tone: string, mode: string): string {
+  const base = tones[tone] || tones.kind;
+  return `${base} [mode: ${mode}]\n\n${safetyFooter}`;
+}

--- a/apps/companion_web/server/compliance/check.ts
+++ b/apps/companion_web/server/compliance/check.ts
@@ -1,0 +1,15 @@
+import policies from './state_policies.json';
+
+export type Mode = 'therapy' | 'friend' | 'journal' | 'friend+journal';
+
+/**
+ * Gate requested companion mode based on jurisdiction policies.
+ * If therapy is restricted for a jurisdiction, we fall back to friend+journal mode.
+ */
+export function gateCompanionMode(requested: Mode, jurisdiction: string): Mode {
+  const policy = (policies as Record<string, { therapy?: boolean }>)[jurisdiction];
+  if (requested === 'therapy' && policy && policy.therapy === false) {
+    return 'friend+journal';
+  }
+  return requested;
+}

--- a/apps/companion_web/server/compliance/state_policies.json
+++ b/apps/companion_web/server/compliance/state_policies.json
@@ -1,0 +1,4 @@
+{
+  "US-IL": { "therapy": false },
+  "US-CA": { "therapy": true }
+}


### PR DESCRIPTION
## Summary
- add file-backed store and safety-footed checkup messages
- expose checkup prefs/read/send API with compliance gating
- include admin preview UI, daily cron job and chat sidebar settings panel

## Testing
- `npm --workspace apps/companion_web run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689a8081f3a8832ebc5f31ee2d7d2de8