### PR TITLE
feat: add games page with animated tabs

### DIFF
--- a/apps/companion_web/app/games/page.tsx
+++ b/apps/companion_web/app/games/page.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+
+const GAMES = [
+  {
+    id: 'module-battle',
+    title: 'Module Battle',
+    blurb: 'Use AI “skills” (fire/ice/mind) to beat glitches. Short runs, high scores.',
+  },
+  {
+    id: 'dream-arena',
+    title: 'Dream Arena',
+    blurb: 'Surreal prompts from the Imagination Core. Story-driven bouts.',
+  },
+  {
+    id: 'guardian-defense',
+    title: 'Guardian Defense',
+    blurb: 'Scan threats, counter with safety moves. Beat the risk score.',
+  },
+];
+
+export default function GamesPage() {
+  const [active, setActive] = useState<string>('module-battle');
+
+  return (
+    <main className="min-h-screen px-6 py-10 bg-black text-white">
+      <header className="mb-8">
+        <h1 className="text-3xl font-semibold">Games</h1>
+        <p className="text-sm text-zinc-400">Just for fun. Your core app stays separate.</p>
+      </header>
+
+      {/* Tabs */}
+      <div className="flex gap-2 mb-6">
+        {GAMES.map(g => (
+          <button
+            key={g.id}
+            onClick={() => setActive(g.id)}
+            className={`relative px-4 py-2 rounded-md border border-zinc-800 transition
+              ${active === g.id ? 'bg-zinc-900' : 'bg-zinc-950 hover:bg-zinc-900'}`}
+          >
+            <span className="text-sm">{g.title}</span>
+            {active === g.id && (
+              <motion.div
+                layoutId="pill"
+                className="absolute inset-0 rounded-md ring-1 ring-cyan-400/30"
+                transition={{ type: 'spring', stiffness: 400, damping: 30 }}
+              />
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Animated panel switch */}
+      <div className="relative">
+        <AnimatePresence mode="wait">
+          <motion.section
+            key={active}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.18 }}
+            className="rounded-xl border border-zinc-800 bg-zinc-950 p-5"
+          >
+            <GamePanel id={active} />
+          </motion.section>
+        </AnimatePresence>
+      </div>
+    </main>
+  );
+}
+
+function GamePanel({ id }: { id: string }) {
+  const game = GAMES.find(g => g.id === id)!;
+  return (
+    <div className="grid gap-4 md:grid-cols-[1fr,320px]">
+      <div>
+        <h2 className="text-xl font-medium">{game.title}</h2>
+        <p className="text-zinc-400 text-sm mb-4">{game.blurb}</p>
+        <IframePreview id={id} />
+      </div>
+      <Sidebar id={id} />
+    </div>
+  );
+}
+
+function IframePreview({ id }: { id: string }) {
+  // Later: replace with your actual web UIs for each game. For now, placeholder.
+  return (
+    <div className="aspect-video rounded-lg border border-zinc-800 bg-gradient-to-br from-zinc-900 to-black
+                    flex items-center justify-center text-zinc-400">
+      <span>Game canvas for <b>{id}</b> goes here</span>
+    </div>
+  );
+}
+
+function Sidebar({ id }: { id: string }) {
+  return (
+    <div className="rounded-lg border border-zinc-800 bg-black/40 p-4">
+      <h3 className="font-medium mb-2">Actions</h3>
+      <div className="flex flex-col gap-2">
+        <button className="px-3 py-2 rounded-md bg-cyan-600/20 hover:bg-cyan-600/30 border border-cyan-700/40">
+          Start
+        </button>
+        <button className="px-3 py-2 rounded-md bg-zinc-800 hover:bg-zinc-700 border border-zinc-700">
+          How to Play
+        </button>
+        <button className="px-3 py-2 rounded-md bg-zinc-900 hover:bg-zinc-800 border border-zinc-800">
+          Leaderboard
+        </button>
+      </div>
+      <div className="mt-4 text-xs text-zinc-500">
+        Switching tabs uses animated transitions (Framer Motion). Core app unaffected.
+      </div>
+    </div>
+  );
+}

--- a/apps/companion_web/app/layout.tsx
+++ b/apps/companion_web/app/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'Companion',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/apps/companion_web/package.json
+++ b/apps/companion_web/package.json
@@ -12,7 +12,8 @@
     "react-dom": "^18.3.1",
     "@stripe/stripe-js": "^3.2.0",
     "@simplewebauthn/browser": "^13.1.2",
-    "@simplewebauthn/server": "^13.1.2"
+    "@simplewebauthn/server": "^13.1.2",
+    "framer-motion": "^11.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@simplewebauthn/browser": "^13.1.2",
         "@simplewebauthn/server": "^13.1.2",
         "@stripe/stripe-js": "^3.2.0",
+        "framer-motion": "^11.0.0",
         "next": "^14.2.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -1445,6 +1446,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -1723,6 +1751,21 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.0.0",


### PR DESCRIPTION
## Summary
- add `/games` page with animated tabbed interface using Framer Motion
- include root `app/layout` to enable App Router pages
- add `framer-motion` dependency

## Testing
- `npm --workspace=apps/companion_web run build` *(fails: Type error in pages/api/admin/webauthn/auth-verify.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689ac78129ec832eaac715e47596c883