### PR TITLE
Ensure Lyra responds even on failures

### DIFF
--- a/apps/companion_web/pages/api/lyra.ts
+++ b/apps/companion_web/pages/api/lyra.ts
@@ -14,7 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(200).json({ reply: `(demo:${mode}) ${message}` });
     }
 
-    const r = await fetch('https://api.openai.com/v1/chat/completions', {
+    const openaiRes = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -29,18 +29,24 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }),
     });
 
-    if (!r.ok) {
-      const errText = await r.text();
+    if (!openaiRes.ok) {
+      const errText = await openaiRes.text();
       console.error('[lyra] openai error:', errText);
-      return res.status(500).json({ error: 'OpenAI request failed' });
+      return res
+        .status(500)
+        .json({ error: "Sorry, I'm having trouble responding right now." });
     }
 
-    const data = await r.json();
-    const reply = data?.choices?.[0]?.message?.content?.trim() || '';
-    return res.status(200).json({ reply: reply || '[No response from AI]' });
+    const data = await openaiRes.json();
+    const reply = data?.choices?.[0]?.message?.content?.trim();
+    return res
+      .status(200)
+      .json({ reply: reply ?? "I'm not sure what to say, but I'm here!" });
   } catch (err) {
     console.error('[lyra] error:', err);
-    return res.status(500).json({ error: 'Server error' });
+    return res
+      .status(500)
+      .json({ error: "I'm having trouble replying right now." });
   }
 }
 

--- a/apps/companion_web/pages/index.tsx
+++ b/apps/companion_web/pages/index.tsx
@@ -20,8 +20,17 @@ export default function Home() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ message: text, mode }),
       });
-      const { reply } = await resp.json();
-      setMessages(m => [...m, { role: 'lyra', text: reply || '(no reply)' }]);
+      const data = (await resp.json().catch(() => ({}))) as {
+        reply?: string;
+        error?: string;
+      };
+      const textReply =
+        data.reply ??
+        data.error ??
+        (resp.ok
+          ? "I'm not sure what to say, but I'm here!"
+          : "I'm having trouble replying right now.");
+      setMessages(m => [...m, { role: 'lyra', text: textReply }]);
     } catch (e) {
       console.error('send error', e);
       setMessages(m => [...m, { role: 'lyra', text: '(error sending message)' }]);


### PR DESCRIPTION
## Summary
- Refactor Lyra API to use clearer variable names and return HTTP 500 when upstream OpenAI calls fail
- Handle non-JSON responses and give friendly fallbacks on the client so users always see a reply

## Testing
- `pytest`
- `npm test` (fails: Missing script "test")
- `npm --workspace apps/companion_web run build`


------
https://chatgpt.com/codex/tasks/task_e_689a510211f8832e8acda1929f341055