### PR TITLE
Add TTS endpoint and client audio playback

### DIFF
--- a/apps/companion_web/app/(components)/AdminVoiceGate.tsx
+++ b/apps/companion_web/app/(components)/AdminVoiceGate.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect, useRef, useState } from 'react';
+type SpeechRecognition = any;
 const PHRASE = (process.env.NEXT_PUBLIC_ADMIN_WAKE || "access alpha lyra").toLowerCase();
 
 export default function AdminVoiceGate(){

--- a/apps/companion_web/app/api/tts/route.ts
+++ b/apps/companion_web/app/api/tts/route.ts
@@ -1,0 +1,46 @@
+export const runtime = 'nodejs';
+import { NextRequest } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const { text, voice } = await req.json();
+  if (!text || !String(text).trim()) {
+    return new Response(
+      JSON.stringify({ ok: false, error: 'missing_text' }),
+      { status: 400 }
+    );
+  }
+
+  const model = 'gpt-4o-mini-tts';
+  const chosenVoice = voice || process.env.LYRA_VOICE || 'alloy';
+
+  const res = await fetch('https://api.openai.com/v1/audio/speech', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model,
+      voice: chosenVoice,
+      input: String(text).slice(0, 4000),
+      format: 'mp3'
+    })
+  });
+
+  if (!res.ok) {
+    const err = await res.text().catch(() => '');
+    return new Response(
+      JSON.stringify({ ok: false, error: 'tts_failed', detail: err }),
+      { status: 500 }
+    );
+  }
+
+  const body = res.body!;
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'audio/mpeg',
+      'Cache-Control': 'no-store'
+    }
+  });
+}

--- a/apps/companion_web/app/lib/speech.ts
+++ b/apps/companion_web/app/lib/speech.ts
@@ -1,0 +1,35 @@
+let unlocked = false;
+
+// iOS/Chrome block audio until a user gesture. Call unlock() once from a click/tap.
+export function unlockAudio() {
+  if (unlocked) return;
+  try {
+    const a = new Audio();
+    a.muted = true;
+    a.play().catch(() => {});
+    unlocked = true;
+  } catch {}
+}
+
+export async function speak(text: string, opts?: { voice?: string; volume?: number }) {
+  const r = await fetch('/api/tts', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ text, voice: opts?.voice })
+  });
+  if (!r.ok) {
+    console.warn('TTS failed', await r.text());
+    return false;
+  }
+  const blob = await r.blob();
+  const url = URL.createObjectURL(blob);
+  const audio = new Audio(url);
+  audio.volume = Math.min(Math.max(opts?.volume ?? 0.5, 0), 1);
+  try {
+    await audio.play();
+    return true;
+  } catch (e) {
+    console.warn('Autoplay blocked. User gesture required.');
+    return false;
+  }
+}

--- a/apps/companion_web/pages/index.tsx
+++ b/apps/companion_web/pages/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import AdminVoiceGate from "../app/(components)/AdminVoiceGate";
+import { unlockAudio, speak } from "../app/lib/speech";
 
 const MODES = ['chill','sassy','sage','gremlin'] as const;
 type Mode = typeof MODES[number];
@@ -24,6 +25,7 @@ export default function Home() {
       const data = (await resp.json()) as { reply?: string; error?: string };
       const textReply = data.reply ?? data.error ?? 'I had trouble replying.';
       setMessages(m => [...m, { role: 'lyra', text: textReply }]);
+      void speak(textReply, { voice: 'alloy', volume: 0.45 });
     } catch (e) {
       console.error('send error', e);
       setMessages(m => [...m, { role: 'lyra', text: '(error sending message)' }]);
@@ -34,6 +36,19 @@ export default function Home() {
     <div style={{minHeight:'100vh',background:'#0b0f16',color:'#e6f1ff',padding:'24px',maxWidth:780,margin:'0 auto'}}>
       <h1 style={{fontSize:28,marginBottom:6}}>AITaskFlo</h1>
       <div style={{opacity:.7,marginBottom:16}}>Your personality-driven AI console.</div>
+      <button
+        onClick={() => unlockAudio()}
+        style={{
+          padding: '4px 8px',
+          borderRadius: 6,
+          background: '#121826',
+          border: '1px solid #223',
+          fontSize: 12,
+          marginBottom: 16
+        }}
+      >
+        Enable sound 🔊
+      </button>
 
       <div style={{display:'flex',gap:8,flexWrap:'wrap',marginBottom:16}}>
         {MODES.map(m => (
@@ -51,6 +66,14 @@ export default function Home() {
         {messages.map((m,i)=>(
           <div key={i} style={{margin:'10px 0'}}>
             <b style={{color:m.role==='you'?'#9ff':'#9f9'}}>{m.role==='you'?'You':'Lyra'}</b>: {m.text}
+            {m.role==='lyra' && (
+              <button
+                onClick={() => speak(m.text)}
+                style={{ marginLeft: 8, fontSize: '0.8em', opacity: 0.7 }}
+              >
+                🔊
+              </button>
+            )}
           </div>
         ))}
         {busy && <div style={{opacity:.6,marginTop:8}}>Lyra is typing…</div>}


### PR DESCRIPTION
## Summary
- stream OpenAI TTS via new `/api/tts` route
- play replies in browser with `speak()`/`unlockAudio()` helpers
- speak Lyra replies automatically with replay controls

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ba9e783a0832ebc4927b7793a23f7