### PR TITLE
feat: add source-backed answers and activity log

### DIFF
--- a/apps/companion_web/components/AnswerCard.tsx
+++ b/apps/companion_web/components/AnswerCard.tsx
@@ -1,0 +1,30 @@
+'use client';
+export function AnswerCard({ text, sources, onSpeak }:{
+  text: string;
+  sources: { title:string; url:string }[];
+  onSpeak?: () => void;
+}) {
+  return (
+    <div className="card">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-sm font-medium">Answer</h3>
+        {onSpeak && <button className="btn-ghost text-xs" onClick={onSpeak}>🔊 Speak</button>}
+      </div>
+      <div className="prose prose-invert text-zinc-100 max-w-none whitespace-pre-wrap">{text}</div>
+      <div className="mt-3">
+        <h4 className="text-xs text-zinc-400 mb-1">Sources</h4>
+        <ul className="space-y-1">
+          {sources?.map((s, i) => (
+            <li key={i} className="text-xs text-zinc-300">
+              <span className="badge mr-2">[{i+1}]</span>
+              <a className="underline hover:no-underline" href={s.url} target="_blank" rel="noreferrer">{s.title}</a>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="mt-3 text-[11px] text-zinc-500">
+        Transparent mode: answers include citations and may say “don’t know” when info isn’t in sources.
+      </div>
+    </div>
+  );
+}

--- a/apps/companion_web/pages/_app.tsx
+++ b/apps/companion_web/pages/_app.tsx
@@ -1,0 +1,6 @@
+import type { AppProps } from 'next/app';
+import '../styles.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}

--- a/apps/companion_web/pages/api/answer.ts
+++ b/apps/companion_web/pages/api/answer.ts
@@ -1,0 +1,84 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// simple fetch with timeout
+async function getJSON(url:string, headers:any={}) {
+  const ctrl = new AbortController(); const to = setTimeout(()=>ctrl.abort(), 8000);
+  try {
+    const r = await fetch(url, { headers, signal: ctrl.signal });
+    if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
+    return await r.json();
+  } finally { clearTimeout(to); }
+}
+
+async function wiki(q:string) {
+  const s = await getJSON(`https://en.wikipedia.org/w/api.php?action=query&list=search&format=json&srsearch=${encodeURIComponent(q)}`);
+  const top = s?.query?.search?.[0]; if (!top?.title) return null;
+  const sum = await getJSON(`https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(top.title)}`);
+  return { title: sum?.title||top.title, url: sum?.content_urls?.desktop?.page||`https://en.wikipedia.org/wiki/${encodeURIComponent(top.title)}`, snippet: sum?.extract||'' };
+}
+
+async function hn(q:string) {
+  // quick & dirty: take top stories and filter by query in title
+  const ids: number[] = await getJSON('https://hacker-news.firebaseio.com/v0/topstories.json');
+  const items = await Promise.all(ids.slice(0,50).map(async id => await getJSON(`https://hacker-news.firebaseio.com/v0/item/${id}.json`)));
+  return items.filter((i:any)=>i?.title?.toLowerCase().includes(q.toLowerCase())).slice(0,3)
+    .map((i:any)=>({ title:i.title, url:i.url||`https://news.ycombinator.com/item?id=${i.id}` }));
+}
+
+async function rssTech() {
+  const r = await fetch('https://hnrss.org/frontpage'); // xml
+  const xml = await r.text();
+  const items: { title: string; url: string }[] = [];
+  const regex = /<item>[\s\S]*?<title>(.*?)<\/title>[\s\S]*?<link>(.*?)<\/link>/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(xml)) && items.length < 5) {
+    items.push({ title: match[1], url: match[2] });
+  }
+  return items;
+}
+
+export default async function handler(req:NextApiRequest, res:NextApiResponse) {
+  try {
+    if (req.method !== 'POST') return res.status(405).end();
+    const { question = '' } = (req.body||{}) as { question?: string };
+    const q = String(question).trim(); if (!q) return res.status(400).json({ error: 'missing question' });
+
+    // gather free sources
+    const [w, h, r] = await Promise.all([ wiki(q).catch(()=>null), hn(q).catch(()=>[]), rssTech().catch(()=>[]) ]);
+    const sources = [
+      ...(w ? [w] : []),
+      ...h,
+      ...r.slice(0,2),
+    ].slice(0,6);
+
+    // build context for the model
+    const context = sources.map((s:any,i:number)=>`[${i+1}] ${s.title}\n${s.url}`).join('\n\n');
+
+    // ask OpenAI to answer WITH citations indexes
+    let answerText = 'Demo mode: no OPENAI_API_KEY set.';
+    if (process.env.OPENAI_API_KEY) {
+      const prompt = [
+        `You are Lyra, a careful assistant. Answer the user's question using ONLY the context links.`,
+        `Cite like [1], [2] where relevant. If unknown, say you don't know.`,
+        `Question: ${q}`,
+        `Context:\n${context}`
+      ].join('\n\n');
+
+      const r = await fetch('https://api.openai.com/v1/chat/completions', {
+        method:'POST',
+        headers:{ 'content-type':'application/json', 'authorization':`Bearer ${process.env.OPENAI_API_KEY}` },
+        body: JSON.stringify({ model: 'gpt-4o-mini', temperature: 0.2, messages:[{role:'user', content: prompt}] })
+      });
+      if (!r.ok) {
+        const t = await r.text().catch(()=> '');
+        return res.status(502).json({ error: 'upstream', detail: t.slice(0,400) });
+      }
+      const j = await r.json();
+      answerText = j?.choices?.[0]?.message?.content?.trim() || 'No answer.';
+    }
+
+    res.status(200).json({ answer: answerText, sources });
+  } catch (e:any) {
+    res.status(500).json({ error: e?.message || 'server_error' });
+  }
+}

--- a/apps/companion_web/pages/index.tsx
+++ b/apps/companion_web/pages/index.tsx
@@ -1,34 +1,72 @@
 import { useState } from 'react';
 import AdminVoiceGate from "../app/(components)/AdminVoiceGate";
 import { unlockAudio, speak } from "../app/lib/speech";
-
-const MODES = ['chill','sassy','sage','gremlin'] as const;
-type Mode = typeof MODES[number];
+import { AnswerCard } from "../components/AnswerCard";
 
 export default function Home() {
-  const [mode, setMode] = useState<Mode>('chill');
+  const [mode, setMode] = useState<'credible'|'creative'>('credible');
   const [input, setInput] = useState('');
   const [busy, setBusy] = useState(false);
-  const [messages, setMessages] = useState<{role:'you'|'lyra';text:string}[]>([]);
+  const [messages, setMessages] = useState<{role:'you'|'lyra';type:'answer'|'plain';text:string;sources?:{title:string;url:string}[]}[]>([]);
+  const [opsLog, setOpsLog] = useState<{t:number;msg:string}[]>([]);
+
+  async function ask(question: string) {
+    try {
+      const r = await fetch('/api/answer', {
+        method:'POST',
+        headers:{'content-type':'application/json'},
+        body: JSON.stringify({ question })
+      });
+      if (!r.ok) return false;
+      const data = await r.json();
+      setMessages(m => [...m, { role:'lyra', type:'answer', text: data.answer, sources: data.sources }]);
+      setOpsLog(l => [
+        { t: Date.now(), msg: `Answer via /api/answer • sources:${data.sources?.length||0} • model:gpt-4o-mini` },
+        ...l
+      ].slice(0,50));
+      return true;
+    } catch (e) {
+      console.error('ask error', e);
+      return false;
+    }
+  }
+
+  async function sendPlain(question: string) {
+    try {
+      const resp = await fetch('/api/lyra', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: question })
+      });
+      const data = (await resp.json()) as { reply?: string; error?: string };
+      const textReply = data.reply ?? data.error ?? 'I had trouble replying.';
+      setMessages(m => [...m, { role: 'lyra', type:'plain', text: textReply }]);
+      setOpsLog(l => [
+        { t: Date.now(), msg: 'Answer via /api/lyra' },
+        ...l
+      ].slice(0,50));
+    } catch (e) {
+      console.error('sendPlain error', e);
+      setMessages(m => [...m, { role:'lyra', type:'plain', text: '(error sending message)' }]);
+    }
+  }
 
   async function send() {
     const text = input.trim();
     if (!text || busy) return;
     setInput(''); setBusy(true);
-    setMessages(m => [...m, { role:'you', text }]);
+    setMessages(m => [...m, { role:'you', type:'plain', text }]);
     try {
-      const resp = await fetch('/api/lyra', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: text, mode }),
-      });
-      const data = (await resp.json()) as { reply?: string; error?: string };
-      const textReply = data.reply ?? data.error ?? 'I had trouble replying.';
-      setMessages(m => [...m, { role: 'lyra', text: textReply }]);
-      void speak(textReply, { voice: 'alloy', volume: 0.45 });
+      let handled = false;
+      if (mode === 'credible') {
+        handled = await ask(text);
+      }
+      if (!handled) {
+        await sendPlain(text);
+      }
     } catch (e) {
       console.error('send error', e);
-      setMessages(m => [...m, { role: 'lyra', text: '(error sending message)' }]);
+      setMessages(m => [...m, { role: 'lyra', type:'plain', text: '(error sending message)' }]);
     } finally { setBusy(false); }
   }
 
@@ -50,31 +88,30 @@ export default function Home() {
         Enable sound 🔊
       </button>
 
-      <div style={{display:'flex',gap:8,flexWrap:'wrap',marginBottom:16}}>
-        {MODES.map(m => (
-          <button key={m} onClick={()=>setMode(m)}
-            style={{ padding:'8px 12px', borderRadius:10, border:'1px solid #223',
-                     background: m===mode ? 'linear-gradient(90deg,#6ee7,#8af)' : '#121826',
-                     color: m===mode ? '#001' : '#e6f1ff' }}>
-            {m}
-          </button>
-        ))}
+      <div className="card" style={{marginBottom:12,display:'flex',alignItems:'center',justifyContent:'space-between'}}>
+        <div className="text-sm">Mode</div>
+        <div className="flex gap-2" style={{display:'flex',gap:8}}>
+          <button className={`badge ${mode==='credible'?'glow':''}`} onClick={()=>setMode('credible')}>Evidence</button>
+          <button className={`badge ${mode==='creative'?'glow':''}`} onClick={()=>setMode('creative')}>Creative</button>
+        </div>
       </div>
 
       <div style={{border:'1px solid #223',borderRadius:12,padding:12,minHeight:320,background:'#0e1422'}}>
         {messages.length===0 && <div style={{opacity:.6}}>Say hi and I’ll reply…</div>}
         {messages.map((m,i)=>(
-          <div key={i} style={{margin:'10px 0'}}>
-            <b style={{color:m.role==='you'?'#9ff':'#9f9'}}>{m.role==='you'?'You':'Lyra'}</b>: {m.text}
-            {m.role==='lyra' && (
-              <button
-                onClick={() => speak(m.text)}
-                style={{ marginLeft: 8, fontSize: '0.8em', opacity: 0.7 }}
-              >
-                🔊
-              </button>
-            )}
-          </div>
+          m.role==='lyra' && m.type==='answer'
+            ? <AnswerCard key={i} text={m.text} sources={m.sources||[]} onSpeak={()=>speak(m.text)} />
+            : <div key={i} style={{margin:'10px 0'}}>
+                <b style={{color:m.role==='you'?'#9ff':'#9f9'}}>{m.role==='you'?'You':'Lyra'}</b>: {m.text}
+                {m.role==='lyra' && (
+                  <button
+                    onClick={() => speak(m.text)}
+                    style={{ marginLeft: 8, fontSize: '0.8em', opacity: 0.7 }}
+                  >
+                    🔊
+                  </button>
+                )}
+              </div>
         ))}
         {busy && <div style={{opacity:.6,marginTop:8}}>Lyra is typing…</div>}
       </div>
@@ -88,10 +125,23 @@ export default function Home() {
           style={{flex:1,padding:'10px 12px',borderRadius:10,border:'1px solid #223',background:'#0e1422',color:'#e6f1ff'}}
         />
         <button onClick={send} disabled={busy}
-          style={{padding:'10px 16px',borderRadius:10,background:'linear-gradient(90deg,#6ee7,#8af)',border:'none',color:'#001'}}>
+          style={{padding:'10px 16px',borderRadius:10,background:'linear-gradient(90deg,#6ee7,#8af)',border:'none',color:'#001'}}
+        >
           Send
         </button>
       </div>
+
+      <div className="card mt-3" style={{marginTop:12}}>
+        <div className="text-sm font-medium mb-2">Activity</div>
+        <ul className="text-xs text-zinc-400 space-y-1">
+          {opsLog.map((e,i)=> <li key={i}>• {new Date(e.t).toLocaleTimeString()} — {e.msg}</li>)}
+        </ul>
+      </div>
+
+      <div style={{marginTop:12,fontSize:'11px',color:'#71717a'}}>
+        Lyra provides AI-generated assistance with linked sources. Not professional advice.
+      </div>
+
       <AdminVoiceGate />
     </div>
   );

--- a/apps/companion_web/styles.css
+++ b/apps/companion_web/styles.css
@@ -1,0 +1,59 @@
+body {
+  background: #0b0f16;
+  color: #e6f1ff;
+}
+
+.card {
+  border: 1px solid #223;
+  background: #0e1422;
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.badge {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 8px;
+  border: 1px solid #223;
+  background: #121826;
+  color: #e6f1ff;
+  cursor: pointer;
+}
+
+.badge.glow, .glow {
+  background: linear-gradient(90deg,#6ee7,#8af);
+  color: #001;
+}
+
+.btn-ghost {
+  background: none;
+  border: none;
+  color: #e6f1ff;
+  cursor: pointer;
+}
+
+.flex { display: flex; }
+.items-center { align-items: center; }
+.justify-between { justify-content: space-between; }
+.mb-2 { margin-bottom: 0.5rem; }
+.mb-1 { margin-bottom: 0.25rem; }
+.mt-3 { margin-top: 0.75rem; }
+.text-sm { font-size: 0.875rem; }
+.text-xs { font-size: 0.75rem; }
+.font-medium { font-weight: 500; }
+.prose-invert { color: #e6f1ff; }
+.text-zinc-100 { color: #f4f4f5; }
+.text-zinc-300 { color: #d4d4d8; }
+.text-zinc-400 { color: #a1a1aa; }
+.text-zinc-500 { color: #71717a; }
+.space-y-1 li + li { margin-top: 0.25rem; }
+.underline { text-decoration: underline; }
+.hover\:no-underline:hover { text-decoration: none; }
+.max-w-none { max-width: none; }
+.whitespace-pre-wrap { white-space: pre-wrap; }
+.text-[11px] { font-size: 11px; }
+.mr-2 { margin-right: 0.5rem; }
+.gap-2 { gap: 0.5rem; }
+.flex.items-center { display: flex; align-items: center; }
+.flex.gap-2 { display: flex; gap: 0.5rem; }
+.glow { background: linear-gradient(90deg,#6ee7,#8af); color:#001; }


### PR DESCRIPTION
## Summary
- add `/api/answer` endpoint that fetches wiki, HN, and RSS data and asks OpenAI with citations
- create `AnswerCard` component to display answers with sources and speak button
- wire chat UI with evidence/creative modes, activity log, and global styles

## Testing
- `npm --workspace apps/companion_web run build` *(fails: process exited before final message but compiled successfully)*

------
https://chatgpt.com/codex/tasks/task_e_689bb61bfd44832eb43360562779db89