### PR TITLE
Add debug-friendly Lyra API and basic speech synthesis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .env
 apps/companion_api/.env
 apps/companion_web/.env.local
+apps/companion_web/.next/

--- a/apps/companion_web/lib/speak.ts
+++ b/apps/companion_web/lib/speak.ts
@@ -1,0 +1,16 @@
+export function speak(text: string) {
+  try {
+    if (!text) return;
+    window.speechSynthesis.cancel();
+    const u = new SpeechSynthesisUtterance(text);
+    u.rate = 1.0; u.pitch = 1.0; u.volume = 1.0;
+    const use = () => {
+      const vs = window.speechSynthesis.getVoices();
+      const v = vs.find(v => /en/i.test(v.lang)) || vs[0];
+      if (v) u.voice = v;
+      window.speechSynthesis.speak(u);
+    };
+    if (window.speechSynthesis.getVoices().length) use();
+    else window.speechSynthesis.onvoiceschanged = use;
+  } catch {}
+}

--- a/apps/companion_web/pages/api/debug/status.ts
+++ b/apps/companion_web/pages/api/debug/status.ts
@@ -1,0 +1,13 @@
+export default async function handler(_req: any, res: any) {
+  const env = { OPENAI_API_KEY: !!process.env.OPENAI_API_KEY, DEBUG: process.env.NEXT_PUBLIC_LYRA_DEBUG === '1' };
+  let openai = { ok:false, note:'' } as { ok: boolean; note: string };
+  if (env.OPENAI_API_KEY) {
+    try {
+      const r = await fetch('https://api.openai.com/v1/models', {
+        headers: { authorization: `Bearer ${process.env.OPENAI_API_KEY}` }
+      });
+      openai.ok = r.ok; openai.note = r.ok ? 'reachable' : `HTTP ${r.status}`;
+    } catch (e: any) { openai.note = e?.message || 'network error'; }
+  } else { openai.note = 'no key (demo/echo)'; }
+  res.status(200).json({ env, openai });
+}

--- a/apps/companion_web/pages/index.tsx
+++ b/apps/companion_web/pages/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import AdminVoiceGate from "../app/(components)/AdminVoiceGate";
-import { unlockAudio, speak } from "../app/lib/speech";
+import { speak } from "../lib/speak";
 
 const MODES = ['chill','sassy','sage','gremlin'] as const;
 type Mode = typeof MODES[number];
@@ -25,10 +25,12 @@ export default function Home() {
       const data = (await resp.json()) as { reply?: string; error?: string };
       const textReply = data.reply ?? data.error ?? 'I had trouble replying.';
       setMessages(m => [...m, { role: 'lyra', text: textReply }]);
-      void speak(textReply, { voice: 'alloy', volume: 0.45 });
+      speak(textReply);
     } catch (e) {
       console.error('send error', e);
-      setMessages(m => [...m, { role: 'lyra', text: '(error sending message)' }]);
+      const fallback = '⚠️ Network wobble. Echoing for now.';
+      setMessages(m => [...m, { role: 'lyra', text: fallback }]);
+      speak(fallback);
     } finally { setBusy(false); }
   }
 
@@ -36,19 +38,6 @@ export default function Home() {
     <div style={{minHeight:'100vh',background:'#0b0f16',color:'#e6f1ff',padding:'24px',maxWidth:780,margin:'0 auto'}}>
       <h1 style={{fontSize:28,marginBottom:6}}>AITaskFlo</h1>
       <div style={{opacity:.7,marginBottom:16}}>Your personality-driven AI console.</div>
-      <button
-        onClick={() => unlockAudio()}
-        style={{
-          padding: '4px 8px',
-          borderRadius: 6,
-          background: '#121826',
-          border: '1px solid #223',
-          fontSize: 12,
-          marginBottom: 16
-        }}
-      >
-        Enable sound 🔊
-      </button>
 
       <div style={{display:'flex',gap:8,flexWrap:'wrap',marginBottom:16}}>
         {MODES.map(m => (
@@ -80,6 +69,12 @@ export default function Home() {
       </div>
 
       <div style={{display:'flex',gap:8,marginTop:12}}>
+        <button
+          onClick={() => speak('Sound enabled')}
+          style={{padding:'10px 12px',borderRadius:10,border:'1px solid #223',background:'#0e1422',color:'#e6f1ff'}}
+        >
+          Enable sound 🔊
+        </button>
         <input
           value={input}
           onChange={e=>setInput(e.target.value)}


### PR DESCRIPTION
## Summary
- Allow `/api/lyra` to echo in debug or demo mode and always return a reply
- Add `/api/debug/status` endpoint for quick environment checks
- Introduce browser-based `speak` helper and wire UI to use it with an enable-sound button

## Testing
- `npm --workspace apps/companion_web test` *(fails: Missing script "test")*
- `npm --workspace apps/companion_web run build`


------
https://chatgpt.com/codex/tasks/task_e_689bb70a6ee4832e80c778ae600b8a7b