### PR TITLE
feat: add research loop scaffolding

### DIFF
--- a/apps/companion_web/README.md
+++ b/apps/companion_web/README.md
@@ -20,3 +20,21 @@ Next.js frontend for the Companion project.
 npm install
 npm run dev
 ```
+
+## Research Loop
+
+Additional environment variables for the automated research loop:
+- `OPENAI_API_KEY`
+- `TAVILY_API_KEY` (optional)
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+- `GITHUB_TOKEN`
+- `REPO_FULL_NAME`
+- `EMAIL_FROM`
+- `EMAIL_TO`
+- `SMTP_HOST`
+- `SMTP_PORT`
+- `SMTP_USER`
+- `SMTP_PASS`
+- `RESEARCH_SAFE_MODE`
+- `RESEARCH_CRON_SECRET`

--- a/apps/companion_web/app/lib/research/utils.ts
+++ b/apps/companion_web/app/lib/research/utils.ts
@@ -1,0 +1,21 @@
+export async function safeFetchJSON(url: string, headers: Record<string,string> = {}, ms = 12000) {
+  const ctrl = new AbortController(); const to = setTimeout(()=>ctrl.abort(), ms);
+  try {
+    const r = await fetch(url, { headers, signal: ctrl.signal });
+    if (!r.ok) throw new Error(`${r.status} ${r.statusText}`);
+    return await r.json();
+  } finally { clearTimeout(to); }
+}
+
+export function riskGate(text: string): {allowed: boolean, reason?: string} {
+  const blocked = [
+    /exploit|malware|weapon|biohazard|overthrow|dox/i,
+    /self[-\s]?harm|suicide|anorexia/i
+  ];
+  if (process.env.RESEARCH_SAFE_MODE === '1') {
+    if (blocked.some(rx => rx.test(text))) return { allowed:false, reason:'violates safety policy' };
+  }
+  return { allowed:true };
+}
+
+export function ts() { return new Date().toISOString(); }

--- a/apps/companion_web/package.json
+++ b/apps/companion_web/package.json
@@ -14,7 +14,8 @@
     "@simplewebauthn/browser": "^13.1.2",
     "@simplewebauthn/server": "^13.1.2",
     "framer-motion": "^11.0.0",
-    "@supabase/supabase-js": "^2.43.1"
+    "@supabase/supabase-js": "^2.43.1",
+    "nodemailer": "^6.9.8"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/apps/companion_web/pages/api/cron/research.ts
+++ b/apps/companion_web/pages/api/cron/research.ts
@@ -1,0 +1,191 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { createClient } from '@supabase/supabase-js';
+import { safeFetchJSON, riskGate } from '../../../app/lib/research/utils';
+
+export const config = { api: { bodyParser: false } };
+
+const sb = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!);
+
+async function log(task_id: string, phase: string, payload: any) {
+  await sb.from('research_logs').insert({ task_id, phase, payload });
+}
+
+async function searchBundle(query: string) {
+  // Wiki + arXiv + HN as a minimal trio; Tavily if key exists
+  const [wiki, arxiv, hn] = await Promise.all([
+    safeFetchJSON(`/api/free/wiki?q=${encodeURIComponent(query)}`),
+    safeFetchJSON(`/api/free/arxiv?q=${encodeURIComponent(query)}`).catch(()=>({items:[]})),
+    safeFetchJSON(`/api/free/hn`).catch(()=>([])),
+  ]);
+  return { wiki, arxiv, hn };
+}
+
+async function llmSummarize(objective: string, bundle: any) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    const note = `No OPENAI_API_KEY; heuristic summary: ${bundle?.wiki?.title||'—'}`;
+    return { summary: note, proposals: [] as any[] };
+  }
+  const context = [
+    `Wiki: ${bundle?.wiki?.summary?.extract || ''}`,
+    `arXiv: ${(bundle?.arxiv?.items||[]).map((i:any)=>`${i.title}: ${i.summary}`).join('\n\n')}`,
+    `HN: ${(bundle?.hn||[]).slice(0,5).map((i:any)=>i.title).join('; ')}`
+  ].join('\n\n');
+
+  const prompt = [
+    `Objective: ${objective}`,
+    `Given the context below, produce:`,
+    `1) A concise research summary (<= 180 words).`,
+    `2) Up to 5 safe improvement proposals in JSON: [{type: "prompt|config|code", file?: string, key?: string, value?: any, rationale: string}].`,
+    `Only propose "code" if trivial and safe. Prefer "prompt" or "config" changes.`,
+    `Context:\n${context}`
+  ].join('\n\n');
+
+  const r = await fetch('https://api.openai.com/v1/chat/completions',{
+    method:'POST',
+    headers:{'content-type':'application/json', authorization:`Bearer ${key}`},
+    body: JSON.stringify({ model:'gpt-4o-mini', temperature:0.2, messages:[{role:'user', content:prompt}] })
+  });
+  const j = await r.json();
+  const txt = j?.choices?.[0]?.message?.content || '';
+  const propsMatch = txt.match(/\[([\s\S]*?)\]\s*$/); // last JSON array
+  let proposals:any[] = [];
+  try { proposals = propsMatch ? JSON.parse(propsMatch[0]) : []; } catch {}
+  const summary = txt.replace(/\[([\s\S]*?)\]\s*$/,'').trim();
+  return { summary, proposals };
+}
+
+async function applySafeChanges(task_id: string, proposals: any[]) {
+  const applied:any[] = [], openedPRs:any[] = [], skipped:any[] = [];
+  for (const p of proposals) {
+    const gate = riskGate(JSON.stringify(p));
+    if (!gate.allowed) { skipped.push({ p, reason: gate.reason }); continue; }
+
+    if (p.type === 'config' && p.file && p.key) {
+      // update a JSON config in repo via PR (safer than direct write in prod)
+      const pr = await openPrWithPatch(p.file, async (json:any)=> {
+        json[p.key] = p.value;
+        return json;
+      }, `config: set ${p.key}`);
+      openedPRs.push(pr);
+    } else if (p.type === 'prompt' && p.file) {
+      const pr = await openPrReplaceText(p.file, p.value, `prompt: refresh ${p.file}`);
+      openedPRs.push(pr);
+    } else {
+      skipped.push({ p, reason: 'unsupported or missing fields' });
+    }
+  }
+  await log(task_id,'apply', { applied, openedPRs, skipped });
+  return { applied, openedPRs, skipped };
+}
+
+async function openPrWithPatch(path:string, patcher:(json:any)=>any, title:string) {
+  const gh = (u:string, init:any={}) => fetch(`https://api.github.com${u}`, {
+    ...init,
+    headers:{
+      'authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
+      'accept':'application/vnd.github+json',
+      ...(init.headers||{})
+    }
+  });
+
+  const repo = process.env.REPO_FULL_NAME!;
+  // read current
+  const f = await gh(`/repos/${repo}/contents/${encodeURIComponent(path)}`).then(r=>r.json());
+  const content = Buffer.from(f.content, 'base64').toString('utf8');
+  const json = JSON.parse(content);
+  const updated = patcher(json);
+  const branch = `research/${Date.now()}`;
+  // create branch from default
+  const base = await gh(`/repos/${repo}`).then(r=>r.json());
+  const ref = await gh(`/repos/${repo}/git/ref/heads/${base.default_branch}`).then(r=>r.json());
+  await gh(`/repos/${repo}/git/refs`, { method:'POST', body: JSON.stringify({ ref:`refs/heads/${branch}`, sha: ref.object.sha }) });
+  // commit new file
+  await gh(`/repos/${repo}/contents/${encodeURIComponent(path)}?ref=${branch}`, {
+    method:'PUT',
+    body: JSON.stringify({
+      message: title,
+      content: Buffer.from(JSON.stringify(updated,null,2)).toString('base64'),
+      sha: f.sha,
+      branch
+    })
+  });
+  // open PR
+  const pr = await gh(`/repos/${repo}/pulls`, {
+    method:'POST',
+    body: JSON.stringify({ title, head: branch, base: base.default_branch, body: 'Automated proposal via Research Loop (human review required).' })
+  }).then(r=>r.json());
+  return { number: pr.number, url: pr.html_url };
+}
+
+async function openPrReplaceText(path:string, newText:string, title:string) {
+  const gh = (u:string, init:any={}) => fetch(`https://api.github.com${u}`, {
+    ...init,
+    headers:{
+      'authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
+      'accept':'application/vnd.github+json',
+      ...(init.headers||{})
+    }
+  });
+
+  const repo = process.env.REPO_FULL_NAME!;
+  const f = await gh(`/repos/${repo}/contents/${encodeURIComponent(path)}`).then(r=>r.json());
+  const content = Buffer.from(f.content, 'base64').toString('utf8');
+  const branch = `research/${Date.now()}`;
+  const base = await gh(`/repos/${repo}`).then(r=>r.json());
+  const ref = await gh(`/repos/${repo}/git/ref/heads/${base.default_branch}`).then(r=>r.json());
+  await gh(`/repos/${repo}/git/refs`, { method:'POST', body: JSON.stringify({ ref:`refs/heads/${branch}`, sha: ref.object.sha }) });
+  await gh(`/repos/${repo}/contents/${encodeURIComponent(path)}?ref=${branch}`, {
+    method:'PUT',
+    body: JSON.stringify({
+      message: title,
+      content: Buffer.from(newText).toString('base64'),
+      sha: f.sha,
+      branch
+    })
+  });
+  const pr = await gh(`/repos/${repo}/pulls`, {
+    method:'POST',
+    body: JSON.stringify({ title, head: branch, base: base.default_branch, body: 'Automated proposal via Research Loop (human review required).' })
+  }).then(r=>r.json());
+  return { number: pr.number, url: pr.html_url };
+}
+
+export default async function handler(req:NextApiRequest, res:NextApiResponse) {
+  try {
+    if (req.headers['x-cron-key'] !== process.env.RESEARCH_CRON_SECRET) return res.status(401).json({ error:'unauthorized' });
+
+    // 1) Pull next task
+    const { data: task } = await sb.from('research_tasks').select('*').eq('status','queued').order('priority',{ascending:false}).limit(1).single();
+    if (!task) return res.status(200).json({ ok:true, note:'no queued tasks' });
+
+    await sb.from('research_tasks').update({ status:'running', started_at: new Date().toISOString() }).eq('id', task.id);
+
+    // 2) Search bundle
+    const bundle = await searchBundle(task.objective);
+    await log(task.id, 'search', bundle);
+
+    // 3) Summarize + proposals
+    const { summary, proposals } = await llmSummarize(task.objective, bundle);
+    await log(task.id, 'synthesize', { summary, proposals });
+
+    // 4) Guardrails
+    const gate = riskGate(JSON.stringify({ summary, proposals }));
+    if (!gate.allowed) {
+      await log(task.id,'guard',{ denied:true, reason: gate.reason });
+      await sb.from('research_tasks').update({ status:'failed', finished_at: new Date().toISOString() }).eq('id', task.id);
+      return res.status(200).json({ ok:false, reason:'blocked by guardrails' });
+    }
+
+    // 5) Apply safe changes (via PRs for code; direct for configs only if trivial—in this sample we PR both)
+    const applied = await applySafeChanges(task.id, proposals);
+
+    // 6) Mark done
+    await sb.from('research_tasks').update({ status:'done', finished_at: new Date().toISOString() }).eq('id', task.id);
+
+    res.status(200).json({ ok:true, task, summary, proposals, applied });
+  } catch(e:any) {
+    console.error(e);
+    res.status(500).json({ error: e?.message || 'loop_failed' });
+  }
+}

--- a/apps/companion_web/pages/api/cron/research_email.ts
+++ b/apps/companion_web/pages/api/cron/research_email.ts
@@ -1,0 +1,21 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import nodemailer from 'nodemailer';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!);
+
+async function mail(subject:string, html:string) {
+  const t = nodemailer.createTransport({
+    host: process.env.SMTP_HOST, port: Number(process.env.SMTP_PORT||587), secure: false,
+    auth: { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS }
+  });
+  await t.sendMail({ from: process.env.EMAIL_FROM, to: process.env.EMAIL_TO, subject, html });
+}
+
+export default async function handler(req:NextApiRequest, res:NextApiResponse) {
+  if (req.headers['x-cron-key'] !== process.env.RESEARCH_CRON_SECRET) return res.status(401).json({ error:'unauthorized' });
+  const { data: rows } = await sb.rpc('research_digest_last24');
+  const html = `\n  <h3>Lyra Research Digest</h3>\n  <p>Here’s what I learned & proposed in the last 24h.</p>\n  <pre style="font-family:ui-monospace,monospace">${JSON.stringify(rows || [], null, 2)}</pre>\n  `;
+  await mail('Lyra Research Digest', html);
+  res.status(200).json({ ok:true });
+}

--- a/apps/companion_web/pages/api/free/arxiv.ts
+++ b/apps/companion_web/pages/api/free/arxiv.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+export default async function handler(req:NextApiRequest, res:NextApiResponse) {
+  const q = (req.query.q as string || 'speech+pronunciation');
+  const url = `https://export.arxiv.org/api/query?search_query=all:${encodeURIComponent(q)}&start=0&max_results=5&sortBy=submittedDate&sortOrder=descending`;
+  const r = await fetch(url); const xml = await r.text();
+  const items: any[] = [];
+  const rx = /<entry>[\s\S]*?<title>([\s\S]*?)<\/title>[\s\S]*?<id>([\s\S]*?)<\/id>[\s\S]*?<summary>([\s\S]*?)<\/summary>/g;
+  let m: RegExpExecArray | null;
+  while ((m = rx.exec(xml))) {
+    items.push({ title: m[1].trim(), url: m[2].trim(), summary: m[3].trim() });
+  }
+  res.status(200).json({ items });
+}

--- a/apps/companion_web/supabase/research.sql
+++ b/apps/companion_web/supabase/research.sql
@@ -1,0 +1,25 @@
+-- research_tasks: queue of things Lyra should investigate
+create table if not exists research_tasks (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  objective text not null,
+  status text not null default 'queued', -- queued|running|done|failed
+  priority int not null default 5,
+  created_at timestamptz default now(),
+  started_at timestamptz,
+  finished_at timestamptz
+);
+
+-- research_logs: all steps + artifacts for auditability
+create table if not exists research_logs (
+  id bigint generated always as identity primary key,
+  task_id uuid references research_tasks(id) on delete cascade,
+  phase text not null, -- search|read|score|synthesize|propose|guard|apply|notify|error
+  payload jsonb,
+  created_at timestamptz default now()
+);
+
+-- Seed a first task
+insert into research_tasks (title, objective, priority)
+values ('Improve medical terminology TTS',
+'Find free/open datasets and papers that improve pronunciation and emphasis for clinical terms; propose voice prompt tweaks and a lexicon list.', 8);

--- a/config/rag_sources.json
+++ b/config/rag_sources.json
@@ -1,0 +1,5 @@
+[
+  "https://www.nih.gov",
+  "https://www.who.int",
+  "https://arxiv.org"
+]

--- a/config/voice.json
+++ b/config/voice.json
@@ -1,0 +1,3 @@
+{
+  "medical_emphasis": ["tachycardia", "ischemia"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@supabase/supabase-js": "^2.43.1",
         "framer-motion": "^11.0.0",
         "next": "^14.2.5",
+        "nodemailer": "^6.9.8",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1978,6 +1979,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-assign": {

--- a/prompts/lyra_system.txt
+++ b/prompts/lyra_system.txt
@@ -1,0 +1,1 @@
+You are Lyra, an autonomous research assistant. Summarize findings and propose safe improvements.

--- a/prompts/medical_tts.txt
+++ b/prompts/medical_tts.txt
@@ -1,0 +1,1 @@
+Focus on accurate pronunciation and emphasis for clinical terminology.


### PR DESCRIPTION
## Summary
- add research utilities for safe fetching and risk gating
- implement cron endpoints for research loop and daily digest
- introduce config and prompt files the loop can update

## Testing
- `npm --workspace apps/companion_web run build`


------
https://chatgpt.com/codex/tasks/task_e_689bd244ef68832eb36cd2bc9dc6ce19