### PR TITLE
feat: add action pipeline skeleton

### DIFF
--- a/apps/companion_web/app/api/actions/route.ts
+++ b/apps/companion_web/app/api/actions/route.ts
@@ -1,0 +1,55 @@
+// POST /api/actions
+// body: { intent: string, params?: Record<string, any> }
+// returns: { status, plan?, missing?, consent?, result?, error? }
+
+import { NextRequest, NextResponse } from 'next/server';
+import { planFromIntent } from '@/lib/actions/planner';
+import { checkScopes, needsStrongAuth } from '@/lib/actions/policy';
+import { executePlan } from '@/lib/actions/executor';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json().catch(() => ({}));
+  const intent = String(body.intent || '').trim();
+  const params = (body.params || {}) as Record<string, any>;
+  if (!intent)
+    return NextResponse.json({ status: 'error', error: 'missing_intent' }, { status: 400 });
+
+  // 1) plan
+  const plan = await planFromIntent(intent, params);
+
+  // 2) scopes
+  const { granted, missing } = await checkScopes(plan);
+  if (missing.length) {
+    return NextResponse.json({ status: 'needs_scopes', plan, missing });
+  }
+
+  // 3) consent
+  const needs2FA = needsStrongAuth(plan);
+  const consent = {
+    title: 'Confirm Action',
+    summary: plan.summary,
+    steps: plan.steps.map(s => ({ id: s.id, kind: s.kind, preview: s.preview })),
+    requires2FA: needs2FA,
+    estCostUSD: plan.estimate?.usd ?? 0,
+  };
+  if (!params?.confirm) {
+    return NextResponse.json({ status: 'needs_consent', plan, consent });
+  }
+
+  // (optional) verify TOTP/PIN if plan sensitive
+  if (needs2FA) {
+    const ok = await verifyTotpAndPin(params.totp, params.pin);
+    if (!ok) return NextResponse.json({ status: 'error', error: 'auth_failed' }, { status: 401 });
+  }
+
+  // 4) execute
+  const result = await executePlan(plan);
+  return NextResponse.json({ status: 'ok', result });
+}
+
+async function verifyTotpAndPin(t?: string, p?: string) {
+  if (!t || !p) return false;
+  // TODO: verify with your auth backend; stubbed true for now
+  return true;
+}
+

--- a/apps/companion_web/components/ActionConsentCard.tsx
+++ b/apps/companion_web/components/ActionConsentCard.tsx
@@ -1,0 +1,45 @@
+'use client';
+import { useState } from 'react';
+
+export default function ActionConsentCard({ intent, consent }:{ intent:string; consent:any }) {
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<any>(null);
+
+  async function approve(){
+    setBusy(true);
+    try{
+      const r = await fetch('/api/actions', {
+        method:'POST',
+        headers:{'content-type':'application/json'},
+        body: JSON.stringify({ intent, params:{ confirm:true } })
+      });
+      const j = await r.json();
+      setResult(j.result || j.error || j);
+    }catch(e){
+      setResult({ error:'network_error' });
+    }finally{
+      setBusy(false);
+    }
+  }
+
+  if(result){
+    return (
+      <div className="card" style={{margin:'10px 0'}}>
+        <div className="text-sm font-medium mb-1">Action Result</div>
+        <pre className="text-xs overflow-auto" style={{whiteSpace:'pre-wrap'}}>{JSON.stringify(result, null, 2)}</pre>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card" style={{margin:'10px 0'}}>
+      <div className="text-sm font-medium mb-1">{consent.title}</div>
+      <div className="text-sm mb-2">{consent.summary}</div>
+      <ul className="text-xs mb-2" style={{paddingLeft:'20px',listStyle:'disc'}}>
+        {consent.steps.map((s:any)=>(<li key={s.id}>{s.preview}</li>))}
+      </ul>
+      <div className="text-xs mb-2">Est. cost: ${consent.estCostUSD}</div>
+      <button className="btn" onClick={approve} disabled={busy}>{busy?'Working…':'Approve'}</button>
+    </div>
+  );
+}

--- a/apps/companion_web/lib/actions/executor.ts
+++ b/apps/companion_web/lib/actions/executor.ts
@@ -1,0 +1,24 @@
+import { requestRideDeepLink } from './integrations/rides';
+import { transferFunds } from './integrations/payments';
+import { searchTravel, bookTravel } from './integrations/travel';
+import { searchLodging, requestLodging } from './integrations/lodging';
+import { postSocial } from './integrations/social';
+import { deploySite } from './integrations/deploy';
+import { callStore } from './integrations/voice';
+
+export async function executePlan(plan: any) {
+  const results: any[] = [];
+  for (const step of plan.steps) {
+    if (step.kind === 'rides.request') results.push(await requestRideDeepLink(step.params));
+    else if (step.kind === 'payments.transfer') results.push(await transferFunds(step.params));
+    else if (step.kind === 'travel.search') results.push(await searchTravel(step.params));
+    else if (step.kind === 'travel.book') results.push(await bookTravel(step.params));
+    else if (step.kind === 'lodging.search') results.push(await searchLodging(step.params));
+    else if (step.kind === 'lodging.request') results.push(await requestLodging(step.params));
+    else if (step.kind === 'social.post') results.push(await postSocial(step.params));
+    else if (step.kind === 'site.deploy') results.push(await deploySite(step.params));
+    else if (step.kind === 'voice.call') results.push(await callStore(step.params));
+    else results.push({ step: step.id, skipped: true });
+  }
+  return { plan: plan.summary, steps: plan.steps.length, results };
+}

--- a/apps/companion_web/lib/actions/integrations/deploy.ts
+++ b/apps/companion_web/lib/actions/integrations/deploy.ts
@@ -1,0 +1,4 @@
+export async function deploySite(p: { template: string }) {
+  // Kick off a Vercel Deploy Hook or create a new project from a template.
+  return { status: 'queued', template: p.template, ref: `DEPLOY-${Date.now()}` };
+}

--- a/apps/companion_web/lib/actions/integrations/lodging.ts
+++ b/apps/companion_web/lib/actions/integrations/lodging.ts
@@ -1,0 +1,6 @@
+export async function searchLodging(p: { city: string; guests: number; start: string; days: number }) {
+  return { status: 'ok', search: `Lodging in ${p.city} for ${p.guests}, ${p.start} +${p.days} nights` };
+}
+export async function requestLodging(p: { platform: 'preferred' | 'airbnb' | 'vrbo'; hold: boolean }) {
+  return { status: 'requested', platform: p.platform || 'preferred', ref: `LODGE-${Date.now()}` };
+}

--- a/apps/companion_web/lib/actions/integrations/payments.ts
+++ b/apps/companion_web/lib/actions/integrations/payments.ts
@@ -1,0 +1,8 @@
+// Use a provider like Moov/Stripe Treasury/Unit/Lithic + Plaid/Teller for link.
+// Until then, simulate and log a pending transfer for manual approval.
+
+export async function transferFunds(p: { from: string; to: string; amount: number; memo?: string }) {
+  if (!p.amount || p.amount <= 0) return { error: 'invalid_amount' };
+  // STUB: create a "transfer request" record; your backend later completes via provider API.
+  return { status: 'pending', provider: 'manual', summary: `$${p.amount} ${p.from} → ${p.to}`, memo: p.memo || '' };
+}

--- a/apps/companion_web/lib/actions/integrations/rides.ts
+++ b/apps/companion_web/lib/actions/integrations/rides.ts
@@ -1,0 +1,8 @@
+// Start with universal deep link (user taps to open the app)
+// Later: swap to provider APIs once tokens added.
+export async function requestRideDeepLink(p: { pickup: string; dropoff: string; service: string }) {
+  const u = new URL('https://m.uber.com/ul/'); // generic deeplink
+  if (p.dropoff && typeof p.dropoff === 'string') u.searchParams.set('action', 'setPickup');
+  // NOTE: You should map real lat/lon when available. For now, fallback strings.
+  return { type: 'deeplink', url: u.toString(), note: 'Tap to request in your ride app.' };
+}

--- a/apps/companion_web/lib/actions/integrations/social.ts
+++ b/apps/companion_web/lib/actions/integrations/social.ts
@@ -1,0 +1,4 @@
+export async function postSocial(p: Record<string, any>) {
+  // Start by drafting content for review; later post via Graph/TikTok APIs.
+  return { status: 'drafted', platforms: p.platforms ?? ['facebook', 'instagram', 'tiktok'] };
+}

--- a/apps/companion_web/lib/actions/integrations/travel.ts
+++ b/apps/companion_web/lib/actions/integrations/travel.ts
@@ -1,0 +1,7 @@
+export async function searchTravel(p: { from: string; to: string; start: string; days: number }) {
+  // Start with an affiliate or deep-link search; upgrade later to Amadeus/Booking APIs.
+  return { status: 'ok', search: `Flights ${p.from} ⇄ ${p.to} around ${p.start} for ${p.days} days` };
+}
+export async function bookTravel(p: { hold: boolean }) {
+  return { status: p.hold ? 'held' : 'booked', reference: `TRIP-${Date.now()}` };
+}

--- a/apps/companion_web/lib/actions/integrations/voice.ts
+++ b/apps/companion_web/lib/actions/integrations/voice.ts
@@ -1,0 +1,4 @@
+// Twilio Programmable Voice (later): for now, simulate a call task.
+export async function callStore(p: { phone?: string; script?: string; order?: any }) {
+  return { status: 'queued', phone: p.phone || 'unknown', scriptPreview: (p.script || '').slice(0, 140) };
+}

--- a/apps/companion_web/lib/actions/planner.ts
+++ b/apps/companion_web/lib/actions/planner.ts
@@ -1,0 +1,148 @@
+type Step = {
+  id: string;
+  kind:
+    | 'rides.request'
+    | 'payments.transfer'
+    | 'travel.search'
+    | 'travel.book'
+    | 'lodging.search'
+    | 'lodging.request'
+    | 'social.post'
+    | 'site.deploy'
+    | 'voice.call';
+  params: Record<string, any>;
+  preview: string;
+};
+type Plan = { summary: string; steps: Step[]; estimate?: { usd?: number } };
+
+export async function planFromIntent(intent: string, params: Record<string, any>): Promise<Plan> {
+  const t = intent.toLowerCase();
+
+  // 1) Rides
+  if (/uber|ride|lyft|pick.*up/i.test(t)) {
+    const p = {
+      pickup: params.pickup ?? 'current_location',
+      dropoff: params.dropoff ?? params.destination ?? 'home',
+      service: params.service ?? 'standard',
+    };
+    return {
+      summary: `Request a ride ${p.service} from ${p.pickup} to ${p.dropoff}`,
+      steps: [
+        {
+          id: 'ride1',
+          kind: 'rides.request',
+          params: p,
+          preview: `Open ride-hail link for ${p.service}`,
+        },
+      ],
+    };
+  }
+
+  // 2) Transfer funds
+  if (/transfer|move.*funds|send.*money/i.test(t)) {
+    const p = {
+      from: params.from ?? 'account_1',
+      to: params.to ?? 'account_2',
+      amount: params.amount,
+      memo: params.memo ?? 'Lyra transfer',
+    };
+    return {
+      summary: `Transfer $${p.amount} from ${p.from} to ${p.to}`,
+      steps: [
+        {
+          id: 'pay1',
+          kind: 'payments.transfer',
+          params: p,
+          preview: `$${p.amount} ${p.from} → ${p.to}`,
+        },
+      ],
+      estimate: { usd: 0 }, // ACH cost near-zero
+    };
+  }
+
+  // 3) Trip to Mexico + Airbnb
+  if (/trip.*mexico|book.*mexico/i.test(t)) {
+    const start = params.start ?? 'next Thursday';
+    const days = params.days ?? 7;
+    const guests = params.guests ?? 9;
+    const city = params.city ?? 'Cancún';
+    return {
+      summary: `Plan ${days} days in ${city}, ${guests} guests, starting ${start}.`,
+      steps: [
+        {
+          id: 'fly1',
+          kind: 'travel.search',
+          params: { from: params.from ?? 'ORD', to: 'CUN', start, days },
+          preview: 'Search roundtrip flights',
+        },
+        {
+          id: 'stay1',
+          kind: 'lodging.search',
+          params: { city, guests, start, days },
+          preview: 'Search lodging for 9 guests',
+        },
+        {
+          id: 'book1',
+          kind: 'travel.book',
+          params: { hold: true },
+          preview: 'Hold best flight with 24h cancellation',
+        },
+        {
+          id: 'stay2',
+          kind: 'lodging.request',
+          params: { platform: 'preferred', hold: true },
+          preview: 'Request Airbnb/alt stay',
+        },
+      ],
+    };
+  }
+
+  // 4) Update social profiles
+  if (/update.*(facebook|instagram|ig|tiktok)/i.test(t)) {
+    return {
+      summary: 'Prepare & post updates to connected social accounts',
+      steps: [
+        {
+          id: 'soc1',
+          kind: 'social.post',
+          params,
+          preview: 'Draft + post to FB/IG/TikTok',
+        },
+      ],
+    };
+  }
+
+  // 5) Call a store and place order
+  if (/call.*store|place.*order/i.test(t)) {
+    const p = { phone: params.phone, script: params.script, order: params.order };
+    return {
+      summary: `Place a phone order with the store`,
+      steps: [
+        {
+          id: 'call1',
+          kind: 'voice.call',
+          params: p,
+          preview: `Call ${p.phone || 'the store'} and read script`,
+        },
+      ],
+    };
+  }
+
+  // 6) Setup website
+  if (/setup.*website|create.*site|deploy.*site/i.test(t)) {
+    return {
+      summary: 'Create & deploy a starter site',
+      steps: [
+        {
+          id: 'site1',
+          kind: 'site.deploy',
+          params: { template: params.template ?? 'lyra-starter' },
+          preview: 'Deploy to Vercel',
+        },
+      ],
+    };
+  }
+
+  // default
+  return { summary: 'No known action; chat response only', steps: [] };
+}

--- a/apps/companion_web/lib/actions/policy.ts
+++ b/apps/companion_web/lib/actions/policy.ts
@@ -1,0 +1,11 @@
+export async function checkScopes(plan: { steps: { kind: string }[] }) {
+  const required = new Set(plan.steps.map(s => s.kind));
+  // TODO: read granted scopes from user session/profile
+  const granted = new Set<string>(); // stub
+  const missing = Array.from(required).filter(k => !granted.has(k));
+  return { granted: Array.from(granted), missing };
+}
+
+export function needsStrongAuth(plan: { steps: { kind: string }[] }) {
+  return plan.steps.some(s => /payments\.|transfer|book/.test(s.kind));
+}


### PR DESCRIPTION
## Summary
- add /api/actions router to plan, consent, and execute tasks
- implement planner, policy checks, executor, and stub integrations
- wire chat UI to detect task intents and render consent card

## Testing
- `npm --workspace apps/companion_web run build`
- `npx tsc -p apps/companion_web/tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689be36b64c4832eb73d06625259ef52