### PR TITLE
feat: add mock robot simulator and admin panel

### DIFF
--- a/apps/companion_web/components/AdminHealthPanel.tsx
+++ b/apps/companion_web/components/AdminHealthPanel.tsx
@@ -1,0 +1,80 @@
+'use client';
+import { useEffect, useState } from "react";
+
+type Robot = {
+  id:string; type:string; pose:{x:number;y:number;zone:string};
+  battery:number; status:string; health:{motors:string;cpu:string;tempC:number};
+  lastSeen:number;
+};
+
+export default function AdminHealthPanel() {
+  const [robots, setRobots] = useState<Robot[]>([]);
+  const [log, setLog] = useState<string[]>([]);
+
+  async function refresh() {
+    // fetch two known robots
+    const ids = ["RTU-1", "IVU-1"];
+    const rs: Robot[] = [];
+    for (const id of ids) {
+      const j = await fetch(`/api/robots/${id}/health`).then(r=>r.json()).catch(()=>null);
+      if (j?.robot) rs.push(j.robot);
+    }
+    setRobots(rs);
+  }
+
+  async function dispatchRunner() {
+    const r = await fetch("/api/ops/task", {
+      method:"POST",
+      headers:{ "Content-Type":"application/json" },
+      body: JSON.stringify({ type:"runner.deliver", to:"RAD-3", payload:{ item:"lab_kit", priority:"urgent" } })
+    }).then(r=>r.json());
+    setLog(l=>[`Dispatched: ${JSON.stringify(r?.task||r)}`, ...l].slice(0,20));
+    refresh();
+  }
+
+  async function selfTest(id:string) {
+    const j = await fetch(`/api/robots/${id}/selftest`).then(r=>r.json());
+    setLog(l=>[`Selftest ${id}: ${JSON.stringify(j)}`, ...l].slice(0,20));
+    refresh();
+  }
+
+  useEffect(()=>{ refresh(); const t=setInterval(refresh, 1500); return ()=>clearInterval(t); }, []);
+
+  return (
+    <div className="grid gap-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">Lyra Ops Console</h2>
+        <button onClick={dispatchRunner} className="px-3 py-1 rounded bg-indigo-600 text-white">Dispatch Runner → RAD-3</button>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {robots.map(r=>(
+          <div key={r.id} className="rounded border border-zinc-800 p-3">
+            <div className="flex items-center justify-between">
+              <div className="font-medium">{r.id} • {r.type}</div>
+              <div className={`text-xs ${r.status==="error"?"text-rose-400":"text-emerald-400"}`}>{r.status}</div>
+            </div>
+            <div className="text-sm text-zinc-400">
+              Zone <b>{r.pose.zone}</b> • Pos ({r.pose.x.toFixed(1)},{r.pose.y.toFixed(1)})<br/>
+              Battery <b>{r.battery.toFixed(0)}%</b> • Temp <b>{r.health.tempC.toFixed(1)}°C</b>
+            </div>
+            <div className="mt-2 flex gap-2">
+              <button onClick={()=>selfTest(r.id)} className="px-2 py-1 rounded border border-zinc-700 text-xs">Self-test</button>
+              <button onClick={()=>fetch(`/api/robots/${r.id}/command`, {
+                method:"POST", headers:{ "Content-Type":"application/json" },
+                body: JSON.stringify({ cmd:"goto", args:{ waypoint:"LOBBY" }})
+              })} className="px-2 py-1 rounded border border-zinc-700 text-xs">Send → LOBBY</button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="rounded border border-zinc-800 p-3">
+        <div className="text-sm text-zinc-400 mb-1">Event log</div>
+        <ul className="text-xs space-y-1 max-h-44 overflow-auto">
+          {log.map((line,i)=>(<li key={i} className="text-zinc-500">• {line}</li>))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/companion_web/lib/queue.ts
+++ b/apps/companion_web/lib/queue.ts
@@ -1,0 +1,8 @@
+// Placeholder queue so the API shape matches a future BullMQ swap.
+export type Job<T=any> = { id: string; name: string; data: T; createdAt: number };
+const q: Job[] = [];
+export async function addJob<T=any>(name:string, data:T) {
+  const j: Job<T> = { id: Math.random().toString(36).slice(2), name, data, createdAt: Date.now() };
+  q.push(j); return j;
+}
+export function listJobs() { return q.slice().sort((a,b)=>b.createdAt-a.createdAt); }

--- a/apps/companion_web/lib/robots.ts
+++ b/apps/companion_web/lib/robots.ts
@@ -1,0 +1,118 @@
+// Simple in-memory robot fleet + simulator loop.
+// Safe for demos: NO real hardware calls, NO PHI.
+
+export type RobotType = "runner" | "iv" | "surgical";
+export type Robot = {
+  id: string;
+  type: RobotType;
+  pose: { x: number; y: number; zone: string };
+  battery: number; // 0..100
+  status: "idle" | "moving" | "busy" | "error";
+  health: { motors: "ok"|"warn"|"fail"; cpu: "ok"|"warn"|"fail"; tempC: number };
+  lastSeen: number;
+  taskId?: string;
+};
+
+export type Task = {
+  id: string;
+  type: "runner.deliver" | "iv.start";
+  to: string;                      // waypoint/room
+  payload?: Record<string, any>;   // { item: "lab_kit" }
+  status: "queued"|"assigned"|"done"|"error";
+  robotId?: string;
+  createdAt: number;
+  finishedAt?: number;
+};
+
+const robots: Record<string, Robot> = {
+  "RTU-1": { id:"RTU-1", type:"runner", pose:{x:0,y:0,zone:"LOBBY"}, battery: 96, status:"idle",
+    health:{ motors:"ok", cpu:"ok", tempC: 41 }, lastSeen: Date.now() },
+  "IVU-1": { id:"IVU-1", type:"iv", pose:{x:3,y:1,zone:"ER"}, battery: 88, status:"idle",
+    health:{ motors:"ok", cpu:"ok", tempC: 39 }, lastSeen: Date.now() },
+};
+
+const tasks: Record<string, Task> = {};
+const waypoints: Record<string, {x:number;y:number;zone:string}> = {
+  "LOBBY": {x:0,y:0,zone:"LOBBY"},
+  "ER":    {x:3,y:1,zone:"ER"},
+  "RAD-3": {x:8,y:2,zone:"RAD"},
+  "OR-2":  {x:5,y:7,zone:"OR"},
+  "LAB":   {x:2,y:6,zone:"LAB"},
+};
+
+function rnd(n:number) { return Math.random()*n; }
+function clamp(v:number,min:number,max:number){ return Math.max(min, Math.min(max, v)); }
+
+function tickRobot(r: Robot) {
+  // battery drain + temp wiggle
+  r.battery = clamp(r.battery - (r.status==="moving"?0.06:0.02), 5, 100);
+  r.health.tempC = clamp(r.health.tempC + (Math.random()-0.5)*0.8, 35, 70);
+  r.lastSeen = Date.now();
+
+  // simple failure sim
+  if (r.health.tempC > 65 && Math.random()<0.02) {
+    r.status = "error";
+    r.health.motors = "warn";
+    return;
+  }
+
+  // "moving" -> drift toward target coords encoded in pose.zone (waypoint)
+  const wp = waypoints[r.pose.zone];
+  if (!wp) return;
+
+  // drift to wp coords
+  if (r.status === "moving") {
+    const dx = wp.x - r.pose.x;
+    const dy = wp.y - r.pose.y;
+    const step = 0.35;
+    const dist = Math.hypot(dx, dy);
+    if (dist < 0.4) {
+      r.status = "busy"; // arrived, "doing task"
+      setTimeout(()=> {
+        r.status = "idle";
+        if (r.taskId && tasks[r.taskId]) {
+          tasks[r.taskId].status = "done";
+          tasks[r.taskId].finishedAt = Date.now();
+        }
+        r.taskId = undefined;
+      }, 1000 + rnd(1200));
+    } else {
+      r.pose.x += (dx/dist)*step + (Math.random()-0.5)*0.05;
+      r.pose.y += (dy/dist)*step + (Math.random()-0.5)*0.05;
+    }
+  }
+}
+
+setInterval(() => {
+  Object.values(robots).forEach(tickRobot);
+}, 400);
+
+// PUBLIC API
+export function listRobots(): Robot[] { return Object.values(robots); }
+export function getRobot(id:string) { return robots[id]; }
+export function setWaypoint(name:string, x:number, y:number, zone:string) { waypoints[name] = {x,y,zone}; }
+
+export function goto(id:string, waypoint:string): {accepted:boolean, eta_s:number} {
+  const r = robots[id]; const wp = waypoints[waypoint];
+  if (!r || !wp) return { accepted:false, eta_s:0 };
+  r.pose.zone = waypoint;
+  r.status = "moving";
+  const eta = Math.round(Math.hypot(wp.x - r.pose.x, wp.y - r.pose.y) / 0.35);
+  return { accepted:true, eta_s: eta };
+}
+
+export function scheduleTask(task: Task) {
+  tasks[task.id] = task;
+  // naive assign to first idle runner
+  const runner = Object.values(robots).find(r => r.type==="runner" && r.status==="idle");
+  if (runner) {
+    task.status = "assigned";
+    task.robotId = runner.id;
+    runner.taskId = task.id;
+    goto(runner.id, task.to);
+  }
+  return task;
+}
+
+export function getTasks() { return Object.values(tasks).sort((a,b)=>b.createdAt-a.createdAt); }
+

--- a/apps/companion_web/pages/admin/index.tsx
+++ b/apps/companion_web/pages/admin/index.tsx
@@ -1,0 +1,14 @@
+import dynamic from "next/dynamic";
+const AdminHealthPanel = dynamic(()=>import("../../components/AdminHealthPanel"), { ssr:false });
+
+export default function AdminPage() {
+  return (
+    <main className="mx-auto max-w-4xl p-4">
+      <h1 className="text-2xl font-serif mb-4">Admin</h1>
+      <AdminHealthPanel />
+      <p className="mt-6 text-xs text-zinc-500">
+        Demo-only. No clinical use. All data is synthetic. For emergencies, call your local emergency number.
+      </p>
+    </main>
+  );
+}

--- a/apps/companion_web/pages/api/discovery/run.ts
+++ b/apps/companion_web/pages/api/discovery/run.ts
@@ -1,0 +1,59 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+// Free-first discovery: OpenAlex + ClinicalTrials.gov, summarized by OpenAI if key exists.
+async function fetchOpenAlex(topic:string) {
+  const url = `https://api.openalex.org/works?search=${encodeURIComponent(topic)}&per_page=5`;
+  const r = await fetch(url); const j = await r.json();
+  const hits = (j?.results||[]).map((w:any)=>({
+    title: w.title, year: w.publication_year, url: w.id, venue: w?.host_venue?.display_name
+  }));
+  return hits;
+}
+
+async function fetchClinicalTrials(topic:string) {
+  const url = `https://clinicaltrials.gov/api/query/study_fields?expr=${encodeURIComponent(topic)}&fields=BriefTitle,NCTId,Condition,OverallStatus&min_rnk=1&max_rnk=5&fmt=json`;
+  const r = await fetch(url); const j = await r.json();
+  const studies = (j?.StudyFieldsResponse?.StudyFields||[]).map((s:any)=>({
+    nctid: s.NCTId?.[0], title: s.BriefTitle?.[0], status: s.OverallStatus?.[0]
+  }));
+  return studies;
+}
+
+export default async function handler(req:NextApiRequest, res:NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error:"Method not allowed" });
+  const { topic = "" } = req.body || {};
+  if (!topic) return res.status(400).json({ error:"topic required" });
+
+  const [papers, trials] = await Promise.all([
+    fetchOpenAlex(topic).catch(()=>[]),
+    fetchClinicalTrials(topic).catch(()=>[]),
+  ]);
+
+  let summary = `Found ${papers.length} recent papers and ${trials.length} trials for “${topic}”.`;
+  const key = process.env.OPENAI_API_KEY;
+  if (key && papers.length + trials.length > 0) {
+    try {
+      const r = await fetch("https://api.openai.com/v1/chat/completions", {
+        method:"POST",
+        headers:{ "Content-Type":"application/json", "Authorization":`Bearer ${key}` },
+        body: JSON.stringify({
+          model:"gpt-4o-mini",
+          messages:[
+            { role:"system", content:"Summarize for clinicians in 5 bullets. Cite paper titles." },
+            { role:"user", content: JSON.stringify({ papers, trials }) }
+          ],
+          temperature: 0.2
+        })
+      });
+      const j = await r.json();
+      summary = j?.choices?.[0]?.message?.content || summary;
+    } catch { /* keep fallback */ }
+  }
+
+  return res.status(200).json({
+    meta: { paper_count: papers.length, trial_count: trials.length },
+    summary,
+    papers, trials,
+    disclaimer: "Educational summary. Not medical advice."
+  });
+}

--- a/apps/companion_web/pages/api/labs/parse.ts
+++ b/apps/companion_web/pages/api/labs/parse.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+type Lab = { code:string; value:number; unit?:string; sex?: "M"|"F" };
+type Flag = { code:string; flag:"low"|"high"|"critical"; note:string };
+
+// very basic, demo-only reference ranges (adults)
+const ranges: Record<string, {low:number; high:number; unit?:string; note:string}> = {
+  HGB_F: { low:12.0, high:16.0, unit:"g/dL", note:"Hemoglobin (female typical range)" },
+  HGB_M: { low:13.5, high:17.5, unit:"g/dL", note:"Hemoglobin (male typical range)" },
+  WBC:   { low:4.0, high:11.0, unit:"x10^3/µL", note:"White blood cells" },
+  PLT:   { low:150, high:450, unit:"x10^3/µL", note:"Platelets" },
+  GLU:   { low:70,  high:99,  unit:"mg/dL", note:"Fasting glucose (may vary)" },
+};
+
+function evalLab(l:Lab): Flag | null {
+  if (l.code === "HGB") {
+    const key = l.sex === "M" ? "HGB_M" : "HGB_F";
+    const r = ranges[key];
+    if (!r) return null;
+    if (l.value < r.low)  return { code:"HGB", flag:"low", note:`Below typical range. ${r.note}` };
+    if (l.value > r.high) return { code:"HGB", flag:"high", note:`Above typical range. ${r.note}` };
+    return null;
+  }
+  const r = ranges[l.code];
+  if (!r) return null;
+  if (l.value < r.low)  return { code:l.code, flag:"low", note:`Below typical range. ${r.note}` };
+  if (l.value > r.high) return { code:l.code, flag:"high", note:`Above typical range. ${r.note}` };
+  return null;
+}
+
+export default async function handler(req:NextApiRequest, res:NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error:"Method not allowed" });
+  const { panel = [] } = req.body || {};
+  const flags = (panel as Lab[]).map(evalLab).filter(Boolean) as Flag[];
+  const education =
+    "These ranges are generalized and for education only. Lab interpretation depends on context. " +
+    "For urgent concerns or symptoms, seek clinician care or emergency services.";
+  return res.status(200).json({ flags, education, disclaimer: "Not medical advice." });
+}

--- a/apps/companion_web/pages/api/ops/task.ts
+++ b/apps/companion_web/pages/api/ops/task.ts
@@ -1,0 +1,26 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { addJob } from "../../../lib/queue";
+import { scheduleTask, Task } from "../../../lib/robots";
+
+export default async function handler(req:NextApiRequest, res:NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error:"Method not allowed" });
+  try {
+    const { type, to, payload } = req.body || {};
+    if (!type || !to) return res.status(400).json({ error:"type and to required" });
+    const job = await addJob("ops.task", { type, to, payload });
+
+    const task: Task = {
+      id: "tsk_" + job.id,
+      type,
+      to,
+      payload,
+      status: "queued",
+      createdAt: Date.now(),
+    };
+    const assigned = scheduleTask(task);
+    return res.status(200).json({ ok:true, task: assigned });
+  } catch (e:any) {
+    console.error(e);
+    return res.status(500).json({ error:"server" });
+  }
+}

--- a/apps/companion_web/pages/api/robots/[id]/command.ts
+++ b/apps/companion_web/pages/api/robots/[id]/command.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getRobot, goto } from "../../../../lib/robots";
+
+export default async function handler(req:NextApiRequest, res:NextApiResponse) {
+  const { id } = req.query;
+  if (req.method !== "POST") return res.status(405).json({ error:"Method not allowed" });
+  const { cmd, args } = req.body || {};
+  const r = getRobot(String(id));
+  if (!r) return res.status(404).json({ error:"robot_not_found" });
+
+  if (cmd === "goto") {
+    const wp = args?.waypoint;
+    if (!wp) return res.status(400).json({ error:"waypoint required" });
+    const out = goto(r.id, wp);
+    return res.status(200).json({ ok: out.accepted, eta_s: out.eta_s });
+  }
+  return res.status(400).json({ error:"unknown_cmd" });
+}

--- a/apps/companion_web/pages/api/robots/[id]/health.ts
+++ b/apps/companion_web/pages/api/robots/[id]/health.ts
@@ -1,0 +1,9 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getRobot } from "../../../../lib/robots";
+
+export default async function handler(req:NextApiRequest, res:NextApiResponse) {
+  const { id } = req.query;
+  const r = getRobot(String(id));
+  if (!r) return res.status(404).json({ error:"robot_not_found" });
+  return res.status(200).json({ robot: r });
+}

--- a/apps/companion_web/pages/api/robots/[id]/selftest.ts
+++ b/apps/companion_web/pages/api/robots/[id]/selftest.ts
@@ -1,0 +1,18 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getRobot } from "../../../../lib/robots";
+
+export default async function handler(req:NextApiRequest, res:NextApiResponse) {
+  const { id } = req.query;
+  const r = getRobot(String(id));
+  if (!r) return res.status(404).json({ error:"robot_not_found" });
+
+  // quick synthetic checks
+  const checks = [
+    { name:"motors", pass: r.health.motors === "ok" },
+    { name:"cpu", pass: r.health.cpu === "ok" },
+    { name:"temp", pass: r.health.tempC < 65 },
+    { name:"battery", pass: r.battery > 10 },
+  ];
+  const ok = checks.every(c=>c.pass);
+  return res.status(200).json({ ok, checks, tempC: r.health.tempC, battery: r.battery });
+}


### PR DESCRIPTION
## Summary
- add in-memory robot simulator and placeholder queue
- expose ops, robot control, discovery, and lab parsing API routes
- ship admin dashboard panel to dispatch runner tasks and view robot status

## Testing
- `npm --workspace apps/companion_web test` *(fails: Missing script "test")*
- `npm --workspace apps/companion_web run build`

------
https://chatgpt.com/codex/tasks/task_e_689c005e051c832eaf624ca24edb4b75