### PR TITLE
Add knowledge graph curation dashboard and tests

### DIFF
--- a/apps/companion_web/pages/api/med/curate/_supabase.ts
+++ b/apps/companion_web/pages/api/med/curate/_supabase.ts
@@ -1,0 +1,14 @@
+import { createClient } from "@supabase/supabase-js";
+
+export const sb = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE!
+);
+
+export const guard = (req: any, res: any) => {
+  if (req.headers.authorization !== `Bearer ${process.env.ADMIN_TOKEN}`) {
+    res.status(401).json({ error: "Unauthorized" });
+    return false;
+  }
+  return true;
+};

--- a/apps/companion_web/pages/api/med/curate/approve.ts
+++ b/apps/companion_web/pages/api/med/curate/approve.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { sb, guard } from "./_supabase";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  if (!guard(req, res)) return;
+  const { id } = req.body ?? {};
+  if (!id) return res.status(400).json({ error: "Missing id" });
+
+  const { error } = await sb.from("kg_edges").update({ status: "approved" }).eq("id", id);
+  if (error) return res.status(500).json({ error: error.message });
+  res.status(200).json({ ok: true });
+}

--- a/apps/companion_web/pages/api/med/curate/list.ts
+++ b/apps/companion_web/pages/api/med/curate/list.ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { sb, guard } from "./_supabase";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") return res.status(405).json({ error: "Method not allowed" });
+  if (!guard(req, res)) return;
+
+  const { data, error } = await sb.from("kg_edges_pending").select("*").limit(200);
+  if (error) return res.status(500).json({ error: error.message });
+  res.status(200).json({ items: data });
+}

--- a/apps/companion_web/pages/api/med/curate/reject.ts
+++ b/apps/companion_web/pages/api/med/curate/reject.ts
@@ -1,0 +1,13 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { sb, guard } from "./_supabase";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  if (!guard(req, res)) return;
+  const { id } = req.body ?? {};
+  if (!id) return res.status(400).json({ error: "Missing id" });
+
+  const { error } = await sb.from("kg_edges").update({ status: "rejected" }).eq("id", id);
+  if (error) return res.status(500).json({ error: error.message });
+  res.status(200).json({ ok: true });
+}

--- a/apps/companion_web/pages/api/med/graph/query.ts
+++ b/apps/companion_web/pages/api/med/graph/query.ts
@@ -1,0 +1,48 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE!
+);
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  const { question } = (req.body ?? {}) as { question?: string };
+  if (!question) return res.status(400).json({ error: "Missing question" });
+
+  const { data: anchors } = await supabase.rpc("kg_anchor_nodes", { p_query: question, p_k: 5 }).catch(() => ({ data: [] as any[] }));
+  const anchorIds = (anchors ?? []).map((a: any) => a.id);
+
+  const { data: edges } = await supabase
+    .from("kg_edges")
+    .select(
+      "id, rel, confidence, src:kg_nodes!kg_edges_src_id_fkey(id,kind,name), dst:kg_nodes!kg_edges_dst_id_fkey(id,kind,name), evidence:kg_nodes!kg_edges_evidence_id_fkey(id,kind,name,source_url)"
+    )
+    .or(`src_id.in.(${anchorIds.join(",")}),dst_id.in.(${anchorIds.join(",")})`)
+    .eq("status", "approved")
+    .limit(200);
+
+  const lines: string[] = [];
+  for (const e of edges ?? []) {
+    const ev = e.evidence?.source_url ? ` [evidence: ${e.evidence.source_url}]` : "";
+    lines.push(`${e.src.kind}:${e.src.name} --${e.rel}(${e.confidence.toFixed(2)})--> ${e.dst.kind}:${e.dst.name}${ev}`);
+  }
+  if (!lines.length) return res.status(200).json({ abstain: true, reasons: ["No graph context found."] });
+
+  const sys = "Answer strictly from the provided graph facts. If insufficient, say you cannot conclude.";
+  const prompt = `Question: ${question}\n\nGraph facts:\n${lines.join("\n")}\n\nReturn concise answer with bullet points and include the specific edges you relied on.`;
+
+  const r = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${process.env.OPENAI_API_KEY}` },
+    body: JSON.stringify({ model: "gpt-4o-mini", temperature: 0, messages: [{ role: "system", content: sys }, { role: "user", content: prompt }] }),
+  });
+
+  if (!r.ok) return res.status(502).json({ error: "Upstream error." });
+  const j = await r.json();
+  const answer = j.choices?.[0]?.message?.content?.trim();
+  if (!answer) return res.status(200).json({ abstain: true, reasons: ["No answer generated."] });
+
+  return res.status(200).json({ answer, edges: (edges ?? []).length });
+}

--- a/apps/companion_web/pages/api/med/graph/test_clear.ts
+++ b/apps/companion_web/pages/api/med/graph/test_clear.ts
@@ -1,0 +1,12 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { sb } from "../curate/_supabase";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (process.env.NODE_ENV !== "test" && req.headers.authorization !== `Bearer ${process.env.ADMIN_TOKEN}`) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  await sb.from("kg_edges").delete().neq("id", "00000000-0000-0000-0000-000000000000");
+  await sb.from("kg_nodes").delete().neq("id", "00000000-0000-0000-0000-000000000000");
+  res.status(200).json({ ok: true });
+}

--- a/apps/companion_web/pages/api/med/graph/test_seed.ts
+++ b/apps/companion_web/pages/api/med/graph/test_seed.ts
@@ -1,0 +1,33 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { sb } from "../curate/_supabase";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (process.env.NODE_ENV !== "test" && req.headers.authorization !== `Bearer ${process.env.ADMIN_TOKEN}`) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { data: n1 } = await sb
+    .from("kg_nodes")
+    .insert({ kind: "Condition", name: "Asthma" })
+    .select()
+    .single();
+  const { data: n2 } = await sb
+    .from("kg_nodes")
+    .insert({ kind: "Drug", name: "Albuterol" })
+    .select()
+    .single();
+  const { data: n3 } = await sb
+    .from("kg_nodes")
+    .insert({ kind: "Paper", name: "Test RCT", source_url: "https://example.org/pmid-test" })
+    .select()
+    .single();
+  await sb.from("kg_edges").insert({
+    src_id: n2!.id,
+    dst_id: n1!.id,
+    rel: "treats",
+    confidence: 0.95,
+    evidence_id: n3!.id,
+    status: "approved",
+  });
+  res.status(200).json({ ok: true });
+}

--- a/apps/companion_web/pages/api/med/graph/upsert.ts
+++ b/apps/companion_web/pages/api/med/graph/upsert.ts
@@ -1,0 +1,53 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { createClient } from "@supabase/supabase-js";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE!
+);
+
+type NodeIn = { kind: string; name: string; canonical_id?: string; source_url?: string; embedding?: number[] };
+type EdgeIn = { src_key: string; dst_key: string; rel: string; evidence_key?: string; confidence: number; justification?: string; snippet?: string };
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  const { nodes = [], edges = [] } = (req.body ?? {}) as { nodes: NodeIn[]; edges: EdgeIn[] };
+
+  const keyToId: Record<string, string> = {};
+  for (const [i, n] of nodes.entries()) {
+    const { data, error } = await supabase.rpc("kg_upsert_node", {
+      p_kind: n.kind,
+      p_name: n.name,
+      p_canonical_id: n.canonical_id ?? null,
+      p_source_url: n.source_url ?? null,
+      p_embedding: n.embedding ?? null,
+    });
+    if (error) return res.status(500).json({ error: error.message });
+    keyToId[`n${i}`] = (data as any).id;
+  }
+
+  for (const e of edges) {
+    const { data, error } = await supabase
+      .from("kg_edges")
+      .insert({
+        src_id: keyToId[e.src_key],
+        dst_id: keyToId[e.dst_key],
+        rel: e.rel,
+        evidence_id: e.evidence_key ? keyToId[e.evidence_key] : null,
+        confidence: e.confidence,
+      })
+      .select("id")
+      .single();
+    if (error) return res.status(500).json({ error: error.message });
+
+    await supabase.from("kg_assertions").insert({
+      edge_id: (data as any).id,
+      author: "pipeline:ingest",
+      method: "RAG+LLM-extract",
+      justification: e.justification ?? null,
+      raw_snippet: e.snippet ?? null,
+    });
+  }
+
+  return res.status(200).json({ ok: true, nodes: Object.values(keyToId).length, edges: edges.length });
+}

--- a/apps/companion_web/pages/med/curate.tsx
+++ b/apps/companion_web/pages/med/curate.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+
+type Item = {
+  id: string;
+  rel: string;
+  confidence: number;
+  src_name: string;
+  src_kind: string;
+  dst_name: string;
+  dst_kind: string;
+  ev_name?: string;
+  ev_url?: string;
+};
+
+export default function CuratePage() {
+  const [items, setItems] = useState<Item[]>([]);
+  const [token, setToken] = useState<string>("");
+
+  async function load() {
+    const r = await fetch("/api/med/curate/list", { headers: { Authorization: `Bearer ${token}` } });
+    const j = await r.json();
+    setItems(j.items ?? []);
+  }
+  useEffect(() => {
+    if (token) load();
+  }, [token]);
+
+  async function act(id: string, path: "approve" | "reject") {
+    await fetch(`/api/med/curate/${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Authorization: `Bearer ${token}` },
+      body: JSON.stringify({ id }),
+    });
+    await load();
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto p-6 text-zinc-100">
+      <h1 className="text-2xl font-semibold mb-2">Knowledge Graph — Curation</h1>
+      <p className="mb-4 text-sm text-zinc-400">Paste admin token to manage pending relations.</p>
+      <input
+        className="w-full mb-4 bg-zinc-800 border border-zinc-700 rounded px-3 py-2"
+        placeholder="Admin token"
+        value={token}
+        onChange={(e) => setToken(e.target.value)}
+      />
+      <button onClick={load} className="mb-6 px-3 py-2 rounded bg-sky-600 hover:bg-sky-500">
+        Refresh
+      </button>
+      <div className="space-y-3">
+        {items.map((it) => (
+          <div key={it.id} className="rounded border border-zinc-700 p-3">
+            <div className="text-sm">
+              <b>{it.src_kind}</b>: {it.src_name}
+              <span className="mx-2">
+                — <i className="text-sky-400">{it.rel}</i> ({it.confidence.toFixed(2)}) —
+              </span>
+              <b>{it.dst_kind}</b>: {it.dst_name}
+            </div>
+            {it.ev_url && (
+              <a className="text-xs text-sky-400" href={it.ev_url} target="_blank" rel="noreferrer">
+                evidence
+              </a>
+            )}
+            <div className="mt-2 space-x-2">
+              <button
+                onClick={() => act(it.id, "approve")}
+                className="px-2 py-1 rounded bg-emerald-600 hover:bg-emerald-500 text-sm"
+              >
+                Approve
+              </button>
+              <button
+                onClick={() => act(it.id, "reject")}
+                className="px-2 py-1 rounded bg-rose-600 hover:bg-rose-500 text-sm"
+              >
+                Reject
+              </button>
+            </div>
+          </div>
+        ))}
+        {!items.length && <div className="text-zinc-400 text-sm">No pending edges.</div>}
+      </div>
+    </div>
+  );
+}

--- a/apps/companion_web/supabase/medical_graph.sql
+++ b/apps/companion_web/supabase/medical_graph.sql
@@ -1,0 +1,87 @@
+-- Medical knowledge graph schema with curation
+create extension if not exists vector;
+
+-- Core nodes
+create table if not exists kg_nodes (
+  id uuid primary key default gen_random_uuid(),
+  kind text not null check (kind in ('Condition','Drug','Gene','Finding','Test','Guideline','Trial','Paper','Org')),
+  name text not null,
+  canonical_id text,
+  source_url text,
+  embedding vector(1536),
+  created_at timestamptz default now()
+);
+create index if not exists kg_nodes_name_idx on kg_nodes using gin (to_tsvector('simple', name));
+create index if not exists kg_nodes_kind_idx on kg_nodes (kind);
+create index if not exists kg_nodes_embedding_idx on kg_nodes (embedding);
+
+-- Typed relationships
+create table if not exists kg_edges (
+  id uuid primary key default gen_random_uuid(),
+  src_id uuid not null references kg_nodes(id) on delete cascade,
+  dst_id uuid not null references kg_nodes(id) on delete cascade,
+  rel text not null,
+  evidence_id uuid references kg_nodes(id) on delete cascade,
+  confidence real not null check (confidence between 0 and 1),
+  status text not null default 'pending' check (status in ('pending','approved','rejected')),
+  created_at timestamptz default now()
+);
+create index if not exists kg_edges_src_id_idx on kg_edges(src_id);
+create index if not exists kg_edges_dst_id_idx on kg_edges(dst_id);
+create index if not exists kg_edges_rel_idx on kg_edges(rel);
+create index if not exists kg_edges_status_idx on kg_edges(status);
+
+-- Provenance assertions
+create table if not exists kg_assertions (
+  id uuid primary key default gen_random_uuid(),
+  edge_id uuid references kg_edges(id) on delete cascade,
+  author text,
+  method text,
+  justification text,
+  raw_snippet text,
+  created_at timestamptz default now()
+);
+
+-- Upsert helper
+create or replace function kg_upsert_node(
+  p_kind text, p_name text, p_canonical_id text, p_source_url text, p_embedding vector
+) returns kg_nodes as $$
+declare r kg_nodes;
+begin
+  insert into kg_nodes (kind,name,canonical_id,source_url,embedding)
+  values (p_kind,p_name,p_canonical_id,p_source_url,p_embedding)
+  on conflict (id) do nothing;
+  select * into r from kg_nodes
+   where lower(name)=lower(p_name) and kind=p_kind and coalesce(canonical_id,'') = coalesce(p_canonical_id,'')
+   limit 1;
+  if r.id is null then
+    insert into kg_nodes (kind,name,canonical_id,source_url,embedding)
+    values (p_kind,p_name,p_canonical_id,p_source_url,p_embedding)
+    returning * into r;
+  end if;
+  return r;
+end; $$ language plpgsql;
+
+-- Anchor search helper
+create or replace function kg_anchor_nodes(p_query text, p_k int default 5)
+returns setof kg_nodes as $$
+begin
+  return query
+  select n.* from kg_nodes n
+  where n.name ilike '%'||p_query||'%'
+  order by length(n.name) asc
+  limit p_k;
+end; $$ language plpgsql;
+
+-- Pending edges view for curation
+create or replace view kg_edges_pending as
+select
+  e.id, e.rel, e.confidence, e.created_at,
+  src.id as src_id, src.kind as src_kind, src.name as src_name,
+  dst.id as dst_id, dst.kind as dst_kind, dst.name as dst_name,
+  ev.id as ev_id, ev.name as ev_name, ev.source_url as ev_url
+from kg_edges e
+join kg_nodes src on src.id = e.src_id
+join kg_nodes dst on dst.id = e.dst_id
+left join kg_nodes ev on ev.id = e.evidence_id
+where e.status = 'pending';

--- a/tests/graph-abstain.spec.ts
+++ b/tests/graph-abstain.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect, request } from "@playwright/test";
+
+const BASE = process.env.BASE_URL!;
+const ADMIN = process.env.ADMIN_TOKEN!;
+
+test.describe("Graph-grounded answering", () => {
+  test("abstains with no evidence, answers with seeded evidence", async ({}) => {
+    const api = await request.newContext({ baseURL: BASE });
+
+    let r = await api.get("/api/med/graph/test_clear", { headers: { Authorization: `Bearer ${ADMIN}` } });
+    expect(r.ok()).toBeTruthy();
+
+    r = await api.post("/api/med/graph/query", { data: { question: "Does albuterol treat asthma?" } });
+    let j = await r.json();
+    expect(r.ok()).toBeTruthy();
+    expect(j.abstain).toBeTruthy();
+
+    r = await api.get("/api/med/graph/test_seed", { headers: { Authorization: `Bearer ${ADMIN}` } });
+    expect(r.ok()).toBeTruthy();
+
+    r = await api.post("/api/med/graph/query", { data: { question: "Does albuterol treat asthma?" } });
+    j = await r.json();
+    expect(r.ok()).toBeTruthy();
+    expect(j.abstain).toBeFalsy();
+    expect(j.edges).toBeGreaterThan(0);
+    expect(String(j.answer)).toMatch(/albuterol/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Add Supabase-backed APIs to list and moderate knowledge graph edges with approval and rejection flows
- Expose web dashboard for reviewing pending relations
- Enforce approved status in graph queries and document schema and Playwright test for abstain/answer behavior

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'apscheduler', 'fastapi')*
- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 BASE_URL=http://localhost:3000 ADMIN_TOKEN=testtoken npx -y playwright@1.54.2 test tests/graph-abstain.spec.ts` *(fails: Cannot find module '@playwright/test')*

------
https://chatgpt.com/codex/tasks/task_e_689c08075e5c832e9e3e1e15d6782523