### PR TITLE
Add page export check and verification docs

### DIFF
--- a/apps/companion_web/README.md
+++ b/apps/companion_web/README.md
@@ -38,3 +38,35 @@ Additional environment variables for the automated research loop:
 - `SMTP_PASS`
 - `RESEARCH_SAFE_MODE`
 - `RESEARCH_CRON_SECRET`
+
+## Verification checklist
+
+1. **Env wiring**
+   - Visit `/api/debug/env` and confirm `openai_key_present` is `true`.
+
+2. **OpenAI reachability**
+   - Use the chat UI or `curl`:
+     ```bash
+     curl -X POST /api/lyra \
+       -H "Content-Type: application/json" \
+       -d '{"message":"ping"}'
+     ```
+   - `502` means an upstream error, `500` a server error, otherwise Lyra replies.
+
+3. **Build guard**
+   - `npm run check:pages` ensures every page exports a default component.
+
+4. **Knowledge graph endpoints**
+   - Upsert:
+     ```bash
+     curl -X POST /api/med/graph/upsert \
+       -H "Content-Type: application/json" \
+       -d '{"nodes":[{"kind":"drug","name":"acetaminophen"}],"edges":[]}'
+     ```
+   - Query:
+     ```bash
+     curl -X POST /api/med/graph/query \
+       -H "Content-Type: application/json" \
+       -d '{"question":"Does acetaminophen affect the liver?"}'
+     ```
+   - Returns evidence lines or `{ "abstain": true }` if no context is found.

--- a/apps/companion_web/package.json
+++ b/apps/companion_web/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",
+    "check:pages": "node scripts/check-pages-default-export.mjs",
+    "prebuild": "npm run check:pages",
     "build": "next build",
     "start": "next start -p 3000"
   },

--- a/apps/companion_web/scripts/check-pages-default-export.mjs
+++ b/apps/companion_web/scripts/check-pages-default-export.mjs
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const pagesDir = path.join(__dirname, '..', 'pages');
+
+const missing = [];
+
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full);
+    } else if (/\.(t|j)sx?$/.test(entry.name)) {
+      if (entry.name.startsWith('_') || entry.name.endsWith('.d.ts')) continue;
+      const content = fs.readFileSync(full, 'utf8');
+      if (!/export\s+default/.test(content)) {
+        missing.push(path.relative(pagesDir, full));
+      }
+    }
+  }
+}
+
+walk(pagesDir);
+
+if (missing.length) {
+  console.error('Missing default export in the following pages:');
+  for (const m of missing) console.error(' - ' + m);
+  process.exit(1);
+} else {
+  console.log('All pages have a default export.');
+}


### PR DESCRIPTION
## Summary
- enforce default exports across Next.js pages with `check:pages` script
- document env, OpenAI, build guard, and knowledge-graph checks in Companion Web README

## Testing
- `npm --workspace apps/companion_web run check:pages`


------
https://chatgpt.com/codex/tasks/task_e_689c58d669f8832eaa7382b33d668a84