### PR TITLE
Improve Lyra API error handling and diagnostics

### DIFF
--- a/apps/companion_web/pages/api/debug/env.ts
+++ b/apps/companion_web/pages/api/debug/env.ts
@@ -1,17 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-// Temporary endpoint to verify environment wiring and network access.
-export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
-  const key = process.env.OPENAI_API_KEY;
-  const hasKey = !!key;
-  const tail = key ? key.slice(-4) : null;
-
-  // Don’t print full key. Only show last 4 to verify wiring.
-  return res.status(200).json({
+export default function handler(_req: NextApiRequest, res: NextApiResponse) {
+  const key = process.env.OPENAI_API_KEY || "";
+  res.status(200).json({
     ok: true,
-    openai_key_present: hasKey,
-    openai_key_tail: tail,
+    openai_key_present: Boolean(key),
+    openai_key_tail: key ? key.slice(-4) : null,
     node_env: process.env.NODE_ENV,
-    vercel_env: process.env.VERCEL_ENV, // "development" | "preview" | "production"
   });
 }
+

--- a/apps/companion_web/pages/api/debug/openai.ts
+++ b/apps/companion_web/pages/api/debug/openai.ts
@@ -1,0 +1,17 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(_req: NextApiRequest, res: NextApiResponse) {
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) return res.status(500).json({ ok: false, reason: "no OPENAI_API_KEY" });
+
+  const r = await fetch("https://api.openai.com/v1/models", {
+    headers: { Authorization: `Bearer ${key}` },
+  }).catch((e) => ({ ok: false, status: 599, text: async () => String(e) } as any));
+
+  const text = await (r as any).text?.().catch(() => "(no body)");
+  return res.status(r.ok ? 200 : (r.status || 502)).json({
+    ok: r.ok,
+    status: r.status || 0,
+    body_sample: String(text).slice(0, 400),
+  });
+}

--- a/apps/companion_web/pages/api/lyra.ts
+++ b/apps/companion_web/pages/api/lyra.ts
@@ -1,49 +1,92 @@
+// pages/api/lyra.ts
 import type { NextApiRequest, NextApiResponse } from "next";
 
-// Minimal Lyra API route that validates env wiring and proxies to OpenAI.
-export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+const OPENAI_URL = "https://api.openai.com/v1/chat/completions";
+const MODEL_ORDER = ["gpt-4o-mini", "gpt-4o", "gpt-3.5-turbo"] as const;
+
+type ChatChoice = { message?: { content?: string } };
+type OpenAIChatRes = { choices?: ChatChoice[] };
+
+function pickMessage(body: any): string {
+  const msg = typeof body?.message === "string" ? body.message : "";
+  return (msg || "").trim() || "Hello!";
+}
+
+async function callOpenAI(
+  key: string,
+  model: string,
+  message: string,
+  rid: string
+): Promise<string> {
+  // 15s guard so the request doesn’t hang forever
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), 15_000);
+
   try {
-    const { message = "" } = (req.body ?? {}) as { message?: string };
-
-    // Sanity: env must exist
-    const key = process.env.OPENAI_API_KEY;
-    if (!key) {
-      console.error("[lyra] missing OPENAI_API_KEY");
-      return res.status(500).json({ error: "Server not configured." });
-    }
-
-    // Health ping: allows ?ping=1 check without burning tokens
-    if (req.query.ping) {
-      return res.status(200).json({ reply: "pong" });
-    }
-
-    // Call OpenAI
-    const openaiRes = await fetch("https://api.openai.com/v1/chat/completions", {
+    const res = await fetch(OPENAI_URL, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${key}`,
       },
       body: JSON.stringify({
-        model: "gpt-4o-mini",
+        model,
         messages: [
           { role: "system", content: "You are Lyra, a concise, friendly assistant." },
           { role: "user", content: message },
         ],
       }),
+      signal: controller.signal,
     });
 
-    if (!openaiRes.ok) {
-      const errText = await openaiRes.text().catch(() => "");
-      console.error("[lyra] upstream error", openaiRes.status, errText);
-      return res.status(502).json({ error: "Upstream error." });
+    if (!res.ok) {
+      // Let caller decide how to handle upstream failures
+      const text = await res.text().catch(() => "");
+      throw new Error(`upstream:${res.status} ${text}`);
     }
 
-    const data = (await openaiRes.json()) as any;
-    const reply: string | undefined = data?.choices?.[0]?.message?.content?.trim();
-    return res.status(200).json({ reply: reply ?? "I'm not sure what to say, but I'm here!" });
-  } catch (e: any) {
-    console.error("[lyra] exception", e?.stack || e?.message || e);
-    return res.status(500).json({ error: "Server error." });
+    const data = (await res.json()) as OpenAIChatRes;
+    const reply = data?.choices?.[0]?.message?.content?.trim();
+    if (!reply) throw new Error("empty_reply");
+    return reply;
+  } finally {
+    clearTimeout(t);
   }
 }
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  // Method guard
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  // Env guard
+  const key = process.env.OPENAI_API_KEY;
+  if (!key) {
+    console.error("[lyra] missing OPENAI_API_KEY");
+    return res.status(500).json({ error: "Server not configured." });
+  }
+
+  const rid = Math.random().toString(36).slice(2, 8);
+  const userMsg = pickMessage(req.body);
+
+  // Try each model; return first success
+  let lastErr: unknown = null;
+  for (const model of MODEL_ORDER) {
+    try {
+      const reply = await callOpenAI(key, model, userMsg, rid);
+      return res.status(200).json({ reply });
+    } catch (e) {
+      lastErr = e;
+      // If the error came from OpenAI, treat as upstream and try next model
+      const msg = (e as Error)?.message || String(e);
+      console.error(`[lyra:${rid}] model ${model} failed ->`, msg);
+      continue;
+    }
+  }
+
+  // All models failed → upstream error
+  console.error(`[lyra:${rid}] all models failed ->`, lastErr);
+  return res.status(502).json({ error: "Upstream error." });
+}
+

--- a/apps/companion_web/pages/api/med/graph/upsert.ts
+++ b/apps/companion_web/pages/api/med/graph/upsert.ts
@@ -14,7 +14,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const { nodes = [], edges = [] } = (req.body ?? {}) as { nodes: NodeIn[]; edges: EdgeIn[] };
 
   const keyToId: Record<string, string> = {};
-  for (const [i, n] of nodes.entries()) {
+  for (let i = 0; i < nodes.length; i++) {
+    const n = nodes[i];
     const { data, error } = await supabase.rpc("kg_upsert_node", {
       p_kind: n.kind,
       p_name: n.name,

--- a/apps/companion_web/pages/index.tsx
+++ b/apps/companion_web/pages/index.tsx
@@ -47,9 +47,13 @@ export default function Home() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ message: question })
       });
-      const data = (await resp.json()) as { reply?: string; error?: string };
-      const textReply = data.reply ?? data.error ?? 'I had trouble replying.';
-      setMessages(m => [...m, { role: 'lyra', type:'plain', text: textReply }]);
+      const data = await resp.json().catch(() => ({}));
+      const textReply =
+        data.reply ??
+        (resp.ok
+          ? "I'm not sure what to say, but I'm here!"
+          : data.error ?? "Upstream error.");
+      setMessages(m => [...m, { role: 'lyra', type: 'plain', text: textReply }]);
       setOpsLog(l => [
         { t: Date.now(), msg: 'Answer via /api/lyra' },
         ...l


### PR DESCRIPTION
## Summary
- Replace `/api/lyra` with a build-safe handler that retries models, times out after 15s, and returns clear JSON replies or errors
- Add `/api/debug/env` and `/api/debug/openai` endpoints to expose environment and verify OpenAI connectivity
- Update chat UI to handle both `{reply}` and `{error}` payloads and fix Supabase graph query typing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm --workspace apps/companion_web run build`


------
https://chatgpt.com/codex/tasks/task_e_689c521fed40832e86757164a58af466