### PR TITLE
Add Lyra AI backend and Next.js frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ dist/
 .env
 apps/companion_api/.env
 apps/companion_web/.env.local
+lyra-ai/frontend/.next/
+lyra-ai/frontend/node_modules/
+lyra-ai/frontend/out/
+!lyra-ai/.env

--- a/lyra-ai/.env
+++ b/lyra-ai/.env
@@ -1,0 +1,4 @@
+OPENAI_API_KEY=your_openai_key
+EMAIL_USER=your_email@example.com
+EMAIL_PASSWORD=your_email_password
+NEXT_PUBLIC_BACKEND_URL=http://localhost:5000

--- a/lyra-ai/Dockerfile
+++ b/lyra-ai/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY backend/requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY backend ./backend
+EXPOSE 5000
+CMD ["python", "backend/app.py"]

--- a/lyra-ai/backend/app.py
+++ b/lyra-ai/backend/app.py
@@ -1,0 +1,25 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+from lyra_core import LyraAI
+
+app = Flask(__name__)
+CORS(app)
+
+lyra = LyraAI(owner_name="Ricky", owner_email="ricardomcastrejon@gmail.com")
+
+@app.route("/chat", methods=["POST"])
+def chat():
+    data = request.get_json()
+    user_message = data.get("message", "")
+    response_text = lyra.respond(user_message)
+    return jsonify({"response": response_text})
+
+@app.route("/learn", methods=["POST"])
+def learn():
+    lyra.learn_security()
+    lyra.learn_medicine()
+    lyra.email_report()
+    return jsonify({"status": "Learning & report sent"})
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/lyra-ai/backend/lyra_core.py
+++ b/lyra-ai/backend/lyra_core.py
@@ -1,0 +1,52 @@
+import datetime
+import os
+import openai
+from utils.emailer import send_email
+from utils.security import SecurityModule
+from utils.tts import speak
+
+openai.api_key = os.getenv("OPENAI_API_KEY", "")
+
+class LyraAI:
+    def __init__(self, owner_name, owner_email):
+        self.owner_name = owner_name
+        self.owner_email = owner_email
+        self.security_module = SecurityModule()
+        self.self_learning_log = []
+        self.current_mode = "default"
+
+    def respond(self, message):
+        if "shutdown" in message.lower():
+            return "Lyra shutting down..."
+        if "medical" in message.lower():
+            self.current_mode = "medical"
+        elif "security" in message.lower():
+            self.current_mode = "security"
+
+        completion = openai.ChatCompletion.create(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": message}]
+        )
+        response_text = completion.choices[0].message.content
+        speak(response_text)
+        self.log_learning("conversation", message)
+        return response_text
+
+    def learn_security(self):
+        threats = ["Example threat X", "Example threat Y"]
+        self.security_module.update(threats)
+        self.log_learning("security", threats)
+
+    def learn_medicine(self):
+        studies = ["Study on cancer detection AI", "New heart surgery robotics"]
+        self.log_learning("medical", studies)
+
+    def log_learning(self, category, data):
+        self.self_learning_log.append({
+            "timestamp": datetime.datetime.now().isoformat(),
+            "category": category,
+            "data": data
+        })
+
+    def email_report(self):
+        send_email(self.owner_email, "Lyra Daily Report", str(self.self_learning_log))

--- a/lyra-ai/backend/requirements.txt
+++ b/lyra-ai/backend/requirements.txt
@@ -1,0 +1,5 @@
+flask
+flask-cors
+openai
+pyttsx3
+speechrecognition

--- a/lyra-ai/backend/utils/emailer.py
+++ b/lyra-ai/backend/utils/emailer.py
@@ -1,0 +1,17 @@
+import os
+import smtplib
+from email.mime.text import MIMEText
+
+EMAIL_USER = os.getenv("EMAIL_USER")
+EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD")
+
+def send_email(to_email, subject, body):
+    msg = MIMEText(body)
+    msg['Subject'] = subject
+    msg['From'] = EMAIL_USER
+    msg['To'] = to_email
+
+    with smtplib.SMTP('smtp.gmail.com', 587) as server:
+        server.starttls()
+        server.login(EMAIL_USER, EMAIL_PASSWORD)
+        server.sendmail(msg['From'], [msg['To']], msg.as_string())

--- a/lyra-ai/backend/utils/security.py
+++ b/lyra-ai/backend/utils/security.py
@@ -1,0 +1,6 @@
+class SecurityModule:
+    def __init__(self):
+        self.threats = []
+
+    def update(self, threats):
+        self.threats.extend(threats)

--- a/lyra-ai/backend/utils/stt.py
+++ b/lyra-ai/backend/utils/stt.py
@@ -1,0 +1,7 @@
+import speech_recognition as sr
+
+def listen():
+    r = sr.Recognizer()
+    with sr.Microphone() as source:
+        audio = r.listen(source)
+    return r.recognize_google(audio)

--- a/lyra-ai/backend/utils/tts.py
+++ b/lyra-ai/backend/utils/tts.py
@@ -1,0 +1,6 @@
+import pyttsx3
+
+def speak(text):
+    engine = pyttsx3.init()
+    engine.say(text)
+    engine.runAndWait()

--- a/lyra-ai/docker-compose.yml
+++ b/lyra-ai/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  backend:
+    build: .
+    ports:
+      - '5000:5000'
+    env_file: .env
+  frontend:
+    build: ./frontend
+    ports:
+      - '3000:3000'
+    environment:
+      - NEXT_PUBLIC_BACKEND_URL=http://backend:5000
+    depends_on:
+      - backend

--- a/lyra-ai/frontend/Dockerfile
+++ b/lyra-ai/frontend/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/lyra-ai/frontend/components/ChatBox.js
+++ b/lyra-ai/frontend/components/ChatBox.js
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import MicButton from './MicButton';
+import ModeBubble from './ModeBubble';
+import MuteToggle from './MuteToggle';
+
+export default function ChatBox() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const [muted, setMuted] = useState(false);
+  const [mode, setMode] = useState('default');
+
+  const sendMessage = async (text) => {
+    if (!text.trim()) return;
+    setMessages((msgs) => [...msgs, { sender: 'user', text }]);
+    const res = await fetch('/api/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: text })
+    });
+    const data = await res.json();
+    const reply = data.response || '';
+    setMessages((msgs) => [...msgs, { sender: 'lyra', text: reply }]);
+    if (!muted && typeof window !== 'undefined') {
+      const utter = new SpeechSynthesisUtterance(reply);
+      window.speechSynthesis.speak(utter);
+    }
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    sendMessage(input);
+    setInput('');
+  };
+
+  const handleTranscript = (transcript) => {
+    setInput(transcript);
+    sendMessage(transcript);
+  };
+
+  return (
+    <div>
+      <ModeBubble mode={mode} />
+      <div className="chat-log">
+        {messages.map((m, i) => (
+          <div key={i} className={m.sender}>{m.text}</div>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit}>
+        <input value={input} onChange={(e) => setInput(e.target.value)} />
+        <button type="submit">Send</button>
+      </form>
+      <MicButton onTranscript={handleTranscript} />
+      <MuteToggle muted={muted} onToggle={() => setMuted(!muted)} />
+    </div>
+  );
+}

--- a/lyra-ai/frontend/components/MicButton.js
+++ b/lyra-ai/frontend/components/MicButton.js
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+export default function MicButton({ onTranscript }) {
+  const [listening, setListening] = useState(false);
+
+  const startListening = () => {
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SpeechRecognition) {
+      alert('Speech recognition not supported.');
+      return;
+    }
+    const recognition = new SpeechRecognition();
+    recognition.onresult = (e) => {
+      const transcript = e.results[0][0].transcript;
+      onTranscript(transcript);
+    };
+    recognition.onend = () => setListening(false);
+    recognition.start();
+    setListening(true);
+  };
+
+  return (
+    <button type="button" onClick={startListening}>
+      {listening ? 'Listening…' : 'Speak'}
+    </button>
+  );
+}

--- a/lyra-ai/frontend/components/ModeBubble.js
+++ b/lyra-ai/frontend/components/ModeBubble.js
@@ -1,0 +1,3 @@
+export default function ModeBubble({ mode }) {
+  return <div className="mode-bubble">Mode: {mode}</div>;
+}

--- a/lyra-ai/frontend/components/MuteToggle.js
+++ b/lyra-ai/frontend/components/MuteToggle.js
@@ -1,0 +1,7 @@
+export default function MuteToggle({ muted, onToggle }) {
+  return (
+    <button type="button" onClick={onToggle}>
+      {muted ? 'Unmute' : 'Mute'}
+    </button>
+  );
+}

--- a/lyra-ai/frontend/package-lock.json
+++ b/lyra-ai/frontend/package-lock.json
@@ -1,0 +1,434 @@
+{
+  "name": "lyra-frontend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lyra-frontend",
+      "version": "1.0.0",
+      "dependencies": {
+        "next": "13.5.4",
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.4.tgz",
+      "integrity": "sha512-LGegJkMvRNw90WWphGJ3RMHMVplYcOfRWf2Be3td3sUa+1AaxmsYyANsA+znrGCBjXJNi4XAQlSoEfUxs/4kIQ==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.4.tgz",
+      "integrity": "sha512-Df8SHuXgF1p+aonBMcDPEsaahNo2TCwuie7VXED4FVyECvdXfRT9unapm54NssV9tF3OQFKBFOdlje4T43VO0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.4.tgz",
+      "integrity": "sha512-siPuUwO45PnNRMeZnSa8n/Lye5ZX93IJom9wQRB5DEOdFrw0JjOMu1GINB8jAEdwa7Vdyn1oJ2xGNaQpdQQ9Pw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.4.tgz",
+      "integrity": "sha512-l/k/fvRP/zmB2jkFMfefmFkyZbDkYW0mRM/LB+tH5u9pB98WsHXC0WvDHlGCYp3CH/jlkJPL7gN8nkTQVrQ/2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.4.tgz",
+      "integrity": "sha512-YYGb7SlLkI+XqfQa8VPErljb7k9nUnhhRrVaOdfJNCaQnHBcvbT7cx/UjDQLdleJcfyg1Hkn5YSSIeVfjgmkTg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.4.tgz",
+      "integrity": "sha512-uE61vyUSClnCH18YHjA8tE1prr/PBFlBFhxBZis4XBRJoR+txAky5d7gGNUIbQ8sZZ7LVkSVgm/5Fc7mwXmRAg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.4.tgz",
+      "integrity": "sha512-qVEKFYML/GvJSy9CfYqAdUexA6M5AklYcQCW+8JECmkQHGoPxCf04iMh7CPR7wkHyWWK+XLt4Ja7hhsPJtSnhg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.4.tgz",
+      "integrity": "sha512-mDSQfqxAlfpeZOLPxLymZkX0hYF3juN57W6vFHTvwKlnHfmh12Pt7hPIRLYIShk8uYRsKPtMTth/EzpwRI+u8w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.4.tgz",
+      "integrity": "sha512-aoqAT2XIekIWoriwzOmGFAvTtVY5O7JjV21giozBTP5c6uZhpvTWRbmHXbmsjZqY4HnEZQRXWkSAppsIBweKqw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.4.tgz",
+      "integrity": "sha512-cyRvlAxwlddlqeB9xtPSfNSCRy8BOa4wtMo0IuI9P7Y0XT2qpDrpFKRyZ7kUngZis59mPVla5k8X1oOJ8RxDYg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+      "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001734",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001734.tgz",
+      "integrity": "sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.5.4.tgz",
+      "integrity": "sha512-+93un5S779gho8y9ASQhb/bTkQF17FNQOtXLKAj3lsNgltEcF0C5PMLLncDmH+8X1EnJH1kbqAERa29nRXqhjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "13.5.4",
+        "@swc/helpers": "0.5.2",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001406",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1",
+        "watchpack": "2.4.0"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=16.14.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "13.5.4",
+        "@next/swc-darwin-x64": "13.5.4",
+        "@next/swc-linux-arm64-gnu": "13.5.4",
+        "@next/swc-linux-arm64-musl": "13.5.4",
+        "@next/swc-linux-x64-gnu": "13.5.4",
+        "@next/swc-linux-x64-musl": "13.5.4",
+        "@next/swc-win32-arm64-msvc": "13.5.4",
+        "@next/swc-win32-ia32-msvc": "13.5.4",
+        "@next/swc-win32-x64-msvc": "13.5.4"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "license": "MIT",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    }
+  }
+}

--- a/lyra-ai/frontend/package.json
+++ b/lyra-ai/frontend/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "lyra-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.5.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/lyra-ai/frontend/pages/_app.js
+++ b/lyra-ai/frontend/pages/_app.js
@@ -1,0 +1,5 @@
+import '../public/styles.css';
+
+export default function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/lyra-ai/frontend/pages/api/chat.js
+++ b/lyra-ai/frontend/pages/api/chat.js
@@ -1,0 +1,18 @@
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).end();
+    return;
+  }
+  try {
+    const backend = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:5000';
+    const response = await fetch(`${backend}/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: req.body.message || '' })
+    });
+    const data = await response.json();
+    res.status(200).json(data);
+  } catch (err) {
+    res.status(500).json({ error: 'Backend error' });
+  }
+}

--- a/lyra-ai/frontend/pages/index.js
+++ b/lyra-ai/frontend/pages/index.js
@@ -1,0 +1,10 @@
+import ChatBox from '../components/ChatBox';
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Lyra AI</h1>
+      <ChatBox />
+    </main>
+  );
+}

--- a/lyra-ai/frontend/public/styles.css
+++ b/lyra-ai/frontend/public/styles.css
@@ -1,0 +1,27 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+.chat-log {
+  border: 1px solid #ccc;
+  padding: 10px;
+  height: 300px;
+  overflow-y: auto;
+  margin-bottom: 10px;
+}
+
+.chat-log .user {
+  text-align: right;
+  color: #0066ff;
+}
+
+.chat-log .lyra {
+  text-align: left;
+  color: #009900;
+}
+
+.mode-bubble {
+  margin-bottom: 10px;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- Add Flask-based Lyra AI backend with learning and email features
- Create Next.js frontend with chat UI, speech controls, and API proxy
- Provide Docker and compose setup with environment configuration

## Testing
- `npm --prefix lyra-ai/frontend run build`
- `python -m py_compile lyra-ai/backend/*.py lyra-ai/backend/utils/*.py`
- `npm --prefix lyra-ai/frontend test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d651da338832e84bbeaced760b8f2