### PR TITLE
Add minimal Lyra admin dashboard interface

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -1,0 +1,46 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #0e0e0e;
+  color: #fff;
+  margin: 0;
+  padding: 20px;
+}
+
+h1, h2 {
+  text-align: center;
+}
+
+.section {
+  margin-bottom: 30px;
+}
+
+.log {
+  border: 1px solid #444;
+  padding: 10px;
+  height: 150px;
+  overflow-y: auto;
+  background: #1e1e1e;
+}
+
+input, textarea {
+  width: 100%;
+  margin-top: 10px;
+  background: #1e1e1e;
+  color: #fff;
+  border: 1px solid #444;
+  padding: 5px;
+}
+
+button {
+  margin-top: 10px;
+  padding: 8px 16px;
+  background: #4CAF50;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  border-radius: 4px;
+}
+
+button:hover {
+  background: #45a049;
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Lyra Admin Dashboard</title>
+  <link rel="stylesheet" href="dashboard.css">
+</head>
+<body>
+  <h1>Lyra Admin Dashboard</h1>
+
+  <div class="section">
+    <h2>Chat</h2>
+    <div id="chatLog" class="log"></div>
+    <input id="chatInput" type="text" placeholder="Type a message..." />
+    <button id="sendBtn">Send</button>
+    <button id="muteBtn">Mute</button>
+  </div>
+
+  <div class="section">
+    <h2>Admin Terminal</h2>
+    <textarea id="terminalInput" placeholder="Python code"></textarea>
+    <button id="runTerminalBtn">Run Code</button>
+  </div>
+
+  <div class="section">
+    <h2>Reports</h2>
+    <button id="getDailyReportBtn">Get Daily Report</button>
+  </div>
+
+  <script src="dashboard.js"></script>
+</body>
+</html>

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,0 +1,66 @@
+const LYRA_API_URL = "http://localhost:5000";
+const ADMIN_KEY = "YOUR_SECRET_ADMIN_KEY";
+let isMuted = false;
+let currentMood = "neutral";
+
+function appendMessage(sender, message) {
+    const log = document.getElementById("chatLog");
+    log.innerHTML += `<p><b>${sender}:</b> ${message}</p>`;
+}
+
+async function lyraSpeak(text, mood = "neutral") {
+    if (isMuted) return;
+    const res = await fetch(`${LYRA_API_URL}/speak`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text, mood })
+    });
+    const audioBlob = await res.blob();
+    new Audio(URL.createObjectURL(audioBlob)).play();
+}
+
+function toggleMute() {
+    isMuted = !isMuted;
+    document.getElementById("muteBtn").textContent = isMuted ? "Unmute" : "Mute";
+}
+
+function autoDetectMood(message) {
+    if (message.includes("sad")) currentMood = "calm";
+    else if (message.includes("excited")) currentMood = "cheerful";
+    else currentMood = "neutral";
+}
+
+document.getElementById("sendBtn").addEventListener("click", async () => {
+    const input = document.getElementById("chatInput").value;
+    autoDetectMood(input);
+    appendMessage("You", input);
+    await lyraSpeak(input, currentMood);
+});
+
+document.getElementById("muteBtn").addEventListener("click", () => {
+    toggleMute();
+});
+
+document.getElementById("runTerminalBtn").addEventListener("click", () => {
+    const code = document.getElementById("terminalInput").value;
+    fetch(`${LYRA_API_URL}/run_code`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "X-Admin-Key": ADMIN_KEY
+        },
+        body: JSON.stringify({ code })
+    })
+    .then(res => res.json())
+    .then(data => {
+        appendMessage("Terminal Output", data.result || data.error);
+    });
+});
+
+document.getElementById("getDailyReportBtn").addEventListener("click", () => {
+    fetch(`${LYRA_API_URL}/daily_report`)
+        .then(res => res.json())
+        .then(data => {
+            appendMessage("📅 Lyra Daily Report", data.report);
+        });
+});


### PR DESCRIPTION
## Summary
- create a simple `dashboard.html` with chat, terminal, and report controls
- style the dashboard with dark theme via `dashboard.css`
- implement `dashboard.js` for mood detection, mute toggle, and API calls

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d770f9088832e92a5f14ee32f83b3