### PR TITLE
Add session activity chart to Streamlit dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ when one is not supplied. Inspect stored history or run a quick demo via:
 python controller.py --test-memory
 ```
 
+### Visualizing Session Activity
+
+The Streamlit dashboard now includes a simple bar chart that displays how many
+records are stored for each session. Launch `app.py` to explore agent interactions
+and view session counts at a glance.
+
 ### Reactive World State
 
 The system now includes a lightweight world state engine that mutates the

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import json
 import asyncio
 
 import streamlit as st
+import pandas as pd
 
 from controller import AgentController
 
@@ -26,8 +27,16 @@ if st.button("Run"):
 
 if controller.memory:
     st.subheader("History")
-    for sid, entries in controller.memory.fetch_all().items():
+    memory_data = controller.memory.fetch_all()
+    for sid, entries in memory_data.items():
         st.write(f"Session {sid}:")
         for item in entries:
             st.json(item)
+
+    # Simple data visualization of session activity
+    session_counts = {sid: len(entries) for sid, entries in memory_data.items()}
+    if session_counts:
+        st.subheader("Session Activity")
+        df = pd.DataFrame(list(session_counts.items()), columns=["session", "entries"]).set_index("session")
+        st.bar_chart(df)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,6 @@ loguru==0.7.2
 # Future AI/LLM integration placeholders
 openai>=1.40.0
 streamlit
+pandas
 requests
 torch


### PR DESCRIPTION
## Summary
- Visualize memory usage in Streamlit app with a bar chart of session activity
- Document the new visualization feature in the README
- Include pandas in requirements for data handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d773b3920832e8fd33df8da846a1a