### PR TITLE
Add Lyra admin backend with voice and terminal

### DIFF
--- a/lyra_admin/app.py
+++ b/lyra_admin/app.py
@@ -1,0 +1,154 @@
+from flask import Flask, request, jsonify, send_file
+import datetime
+import smtplib
+from email.mime.text import MIMEText
+import io
+from gtts import gTTS
+import speech_recognition as sr
+import subprocess
+
+# --- CONFIG ---
+OWNER_NAME = "Ricky"
+OWNER_EMAIL = "ricardomcastrejon@gmail.com"
+GMAIL_USER = "YOUR_EMAIL"       # Set in env vars
+GMAIL_PASS = "YOUR_PASSWORD"    # Set in env vars
+ADMIN_PASSWORD = "supersecret"  # Change this
+
+app = Flask(__name__)
+
+# --- LYRA CLASS ---
+class LyraAI:
+    def __init__(self):
+        self.security_protocols = []
+        self.medical_knowledge_base = {}
+        self.security_knowledge_base = {}
+        self.self_learning_log = []
+        self.muted = False
+        self.current_mood = "neutral"
+
+    def learn_security(self):
+        learned_data = {
+            "date": datetime.date.today().isoformat(),
+            "new_threats": ["Ransomware variant X", "Zero-day in medical device firmware"],
+            "new_protections": ["Firewall AI patch", "Updated encryption protocol"]
+        }
+        self.security_knowledge_base[learned_data["date"]] = learned_data
+        self.security_protocols.extend(learned_data["new_protections"])
+        self.log_learning("Security", learned_data)
+
+    def learn_medicine(self):
+        learned_data = {
+            "date": datetime.date.today().isoformat(),
+            "new_studies": ["Breakthrough in cancer immunotherapy", "Faster stroke detection AI"],
+            "new_treatments": ["Custom CRISPR gene repair", "AI-assisted MRI diagnosis"]
+        }
+        self.medical_knowledge_base[learned_data["date"]] = learned_data
+        self.log_learning("Medical", learned_data)
+
+    def log_learning(self, category, data):
+        entry = {
+            "timestamp": datetime.datetime.now().isoformat(),
+            "category": category,
+            "data": data
+        }
+        self.self_learning_log.append(entry)
+
+    def daily_report(self):
+        report = f"LYRA DAILY REPORT – {datetime.date.today().isoformat()}\n\n"
+        if self.security_knowledge_base.get(datetime.date.today().isoformat()):
+            sec = self.security_knowledge_base[datetime.date.today().isoformat()]
+            report += f"Security Threats: {', '.join(sec['new_threats'])}\n"
+            report += f"Protections: {', '.join(sec['new_protections'])}\n\n"
+        if self.medical_knowledge_base.get(datetime.date.today().isoformat()):
+            med = self.medical_knowledge_base[datetime.date.today().isoformat()]
+            report += f"Medical Studies: {', '.join(med['new_studies'])}\n"
+            report += f"New Treatments: {', '.join(med['new_treatments'])}\n\n"
+        report += f"Self-Learning Entries Today: {len(self.self_learning_log)}\n"
+        return report
+
+    def email_report(self):
+        msg = MIMEText(self.daily_report())
+        msg['Subject'] = f"Lyra AI Update – {datetime.date.today().isoformat()}"
+        msg['From'] = GMAIL_USER
+        msg['To'] = OWNER_EMAIL
+
+        with smtplib.SMTP('smtp.gmail.com', 587) as server:
+            server.starttls()
+            server.login(GMAIL_USER, GMAIL_PASS)
+            server.sendmail(msg['From'], [msg['To']], msg.as_string())
+
+lyra = LyraAI()
+
+# --- ROUTES ---
+
+@app.route("/verify_admin", methods=["POST"])
+def verify_admin():
+    data = request.get_json()
+    if data.get("password") == ADMIN_PASSWORD:
+        return jsonify({"access": True})
+    return jsonify({"access": False})
+
+@app.route("/learn", methods=["POST"])
+def learn():
+    lyra.learn_security()
+    lyra.learn_medicine()
+    lyra.email_report()
+    return jsonify({"status": "Learning complete, email sent"})
+
+@app.route("/daily_report", methods=["GET"])
+def daily_report_api():
+    report_text = lyra.daily_report()
+    try:
+        msg = MIMEText(report_text)
+        msg['Subject'] = f"Lyra AI Update – {datetime.date.today().isoformat()}"
+        msg['From'] = GMAIL_USER
+        msg['To'] = OWNER_EMAIL
+
+        with smtplib.SMTP('smtp.gmail.com', 587) as server:
+            server.starttls()
+            server.login(GMAIL_USER, GMAIL_PASS)
+            server.sendmail(msg['From'], [msg['To']], msg.as_string())
+        status = "Report sent via email."
+    except Exception as e:
+        status = f"Email failed: {e}"
+
+    return jsonify({"status": status, "report": report_text})
+
+@app.route("/speak", methods=["POST"])
+def speak():
+    text = request.json.get("text", "")
+    mood = request.json.get("mood", "neutral")
+    tts = gTTS(text=f"[{mood}] {text}", lang="en")
+    audio_buffer = io.BytesIO()
+    tts.write_to_fp(audio_buffer)
+    audio_buffer.seek(0)
+    return send_file(audio_buffer, mimetype="audio/mpeg")
+
+@app.route("/listen", methods=["GET"])
+def listen():
+    recognizer = sr.Recognizer()
+    with sr.Microphone() as source:
+        audio = recognizer.listen(source)
+    try:
+        transcript = recognizer.recognize_google(audio)
+    except:
+        transcript = ""
+    return jsonify({"transcript": transcript})
+
+@app.route("/terminal", methods=["POST"])
+def terminal():
+    data = request.get_json()
+    cmd = data.get("command")
+    try:
+        result = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, text=True, timeout=10)
+    except subprocess.CalledProcessError as e:
+        result = e.output
+    except Exception as e:
+        result = str(e)
+    return jsonify({"output": result})
+
+if __name__ == "__main__":
+    lyra.learn_security()
+    lyra.learn_medicine()
+    lyra.email_report()
+    app.run(host="0.0.0.0", port=5000)

--- a/lyra_admin/requirements.txt
+++ b/lyra_admin/requirements.txt
@@ -1,0 +1,4 @@
+flask
+gTTS
+SpeechRecognition
+pyaudio

--- a/lyra_admin/static/index.html
+++ b/lyra_admin/static/index.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Lyra Admin Command Center</title>
+<style>
+    body { font-family: Arial, sans-serif; background: #101010; color: #fff; margin: 0; }
+    header { padding: 15px; background: #222; text-align: center; }
+    h1 { margin: 0; color: #4CAF50; }
+    #loginPanel, #adminPanel { max-width: 800px; margin: auto; padding: 20px; }
+    input, button { padding: 8px; margin: 5px; border-radius: 4px; border: none; }
+    button { cursor: pointer; }
+    textarea { width: 100%; height: 150px; background: #000; color: #0f0; font-family: monospace; padding: 10px; }
+    .hidden { display: none; }
+</style>
+</head>
+<body>
+<header>
+    <h1>🔐 Lyra Admin Command Center</h1>
+</header>
+
+<div id="loginPanel">
+    <h2>Admin Login</h2>
+    <input type="password" id="adminPass" placeholder="Enter Admin Password">
+    <button onclick="verifyAdmin()">Login</button>
+    <p id="loginStatus"></p>
+</div>
+
+<div id="adminPanel" class="hidden">
+    <h2>Welcome, Ricky 👋</h2>
+    <button onclick="lyraLearn()">📚 Trigger Learning</button>
+    <button onclick="fetchDailyReport()">📅 Get Daily Report</button>
+    <button onclick="lyraSpeakPrompt()">🗣 Speak</button>
+    <button onclick="lyraListen()">🎤 Listen</button>
+
+    <h3>📜 Output Log</h3>
+    <div id="chatLog" style="background:#111; padding:10px; height:200px; overflow:auto;"></div>
+
+    <h3>💻 Terminal</h3>
+    <textarea id="terminalOutput" readonly></textarea><br>
+    <input type="text" id="terminalInput" placeholder="Type a command">
+    <button onclick="runCommand()">Run</button>
+</div>
+
+<script>
+const LYRA_API_URL = "http://localhost:5000";
+let isMuted = false;
+let currentMood = "neutral";
+
+function verifyAdmin() {
+    const password = document.getElementById("adminPass").value;
+    fetch(`${LYRA_API_URL}/verify_admin`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password })
+    })
+    .then(res => res.json())
+    .then(data => {
+        if (data.access) {
+            document.getElementById("loginPanel").classList.add("hidden");
+            document.getElementById("adminPanel").classList.remove("hidden");
+        } else {
+            document.getElementById("loginStatus").innerText = "❌ Wrong password";
+        }
+    });
+}
+
+function lyraLearn() {
+    fetch(`${LYRA_API_URL}/learn`, { method: "POST" })
+        .then(res => res.json())
+        .then(data => appendMessage("System", data.status));
+}
+
+function fetchDailyReport() {
+    fetch(`${LYRA_API_URL}/daily_report`)
+        .then(res => res.json())
+        .then(data => appendMessage("📅 Lyra Daily Report", data.report));
+}
+
+function lyraSpeakPrompt() {
+    const msg = prompt("What should Lyra say?");
+    if (msg) lyraSpeak(msg);
+}
+
+async function lyraSpeak(text, mood = currentMood) {
+    if (isMuted) return;
+    const res = await fetch(`${LYRA_API_URL}/speak`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text, mood })
+    });
+    const audioBlob = await res.blob();
+    const audioUrl = URL.createObjectURL(audioBlob);
+    new Audio(audioUrl).play();
+}
+
+function lyraListen() {
+    fetch(`${LYRA_API_URL}/listen`)
+        .then(res => res.json())
+        .then(data => appendMessage("🎤 You said", data.transcript));
+}
+
+function runCommand() {
+    const cmd = document.getElementById("terminalInput").value;
+    fetch(`${LYRA_API_URL}/terminal`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ command: cmd })
+    })
+    .then(res => res.json())
+    .then(data => {
+        document.getElementById("terminalOutput").value += `> ${cmd}\n${data.output}\n`;
+        document.getElementById("terminalInput").value = "";
+    });
+}
+
+function appendMessage(sender, msg) {
+    document.getElementById("chatLog").innerHTML += `<p><b>${sender}:</b> ${msg}</p>`;
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask-based Lyra backend with daily learning, admin verification, voice, listening, and terminal APIs
- include static admin panel for triggering learning, reports, speaking, listening, and running shell commands
- document required Python dependencies for Lyra admin app

## Testing
- `pytest`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d77f8073c832e82722cf6449d8695