### PR TITLE
Add password-protected Lyra admin dashboard and Flask backend

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,33 +1,165 @@
-from __future__ import annotations
+from flask import Flask, request, jsonify, send_file
+import datetime
+import smtplib
+from email.mime.text import MIMEText
+import io
+import os
+from gtts import gTTS
+import speech_recognition as sr
+import subprocess
 
-import json
-import asyncio
+app = Flask(__name__)
 
-import streamlit as st
+# --- ENVIRONMENT VARIABLES ---
+OWNER_NAME = "Ricky"
+OWNER_EMAIL = "ricardomcastrejon@gmail.com"
+GMAIL_USER = os.environ.get("GMAIL_USER")
+GMAIL_PASS = os.environ.get("GMAIL_PASS")
+ADMIN_PASSWORD = os.environ.get("ADMIN_PASSWORD", "SuperSecretPassword123")
 
-from controller import AgentController
+# --- LYRA AI CORE ---
+class LyraAI:
+    def __init__(self):
+        self.security_protocols = []
+        self.medical_knowledge_base = {}
+        self.security_knowledge_base = {}
+        self.self_learning_log = []
+        self.muted = False
+        self.current_mood = "neutral"
 
-controller = AgentController(enable_memory=True)
+    def learn_security(self):
+        learned_data = {
+            "date": datetime.date.today().isoformat(),
+            "new_threats": ["Ransomware variant X", "Zero-day in medical device firmware"],
+            "new_protections": ["Firewall AI patch", "Updated encryption protocol"],
+        }
+        self.security_knowledge_base[learned_data["date"]] = learned_data
+        self.security_protocols.extend(learned_data["new_protections"])
+        self.log_learning("Security", learned_data)
 
-st.title("AITaskFlo")
+    def learn_medicine(self):
+        learned_data = {
+            "date": datetime.date.today().isoformat(),
+            "new_studies": ["Breakthrough in cancer immunotherapy", "Faster stroke detection AI"],
+            "new_treatments": ["Custom CRISPR gene repair", "AI-assisted MRI diagnosis"],
+        }
+        self.medical_knowledge_base[learned_data["date"]] = learned_data
+        self.log_learning("Medical", learned_data)
 
-agent_name = st.selectbox("Choose an agent", list(controller.available_agents().keys()))
-input_text = st.text_area("Input JSON", "{}")
+    def log_learning(self, category, data):
+        entry = {
+            "timestamp": datetime.datetime.now().isoformat(),
+            "category": category,
+            "data": data,
+        }
+        self.self_learning_log.append(entry)
 
-if st.button("Run"):
+    def daily_report(self):
+        report = f"LYRA DAILY REPORT – {datetime.date.today().isoformat()}\n\n"
+        if self.security_knowledge_base.get(datetime.date.today().isoformat()):
+            sec = self.security_knowledge_base[datetime.date.today().isoformat()]
+            report += f"Security Threats: {', '.join(sec['new_threats'])}\n"
+            report += f"Protections: {', '.join(sec['new_protections'])}\n\n"
+        if self.medical_knowledge_base.get(datetime.date.today().isoformat()):
+            med = self.medical_knowledge_base[datetime.date.today().isoformat()]
+            report += f"Medical Studies: {', '.join(med['new_studies'])}\n"
+            report += f"New Treatments: {', '.join(med['new_treatments'])}\n\n"
+        report += f"Self-Learning Entries Today: {len(self.self_learning_log)}\n"
+        return report
+
+    def email_report(self):
+        msg = MIMEText(self.daily_report())
+        msg['Subject'] = f"Lyra AI Update – {datetime.date.today().isoformat()}"
+        msg['From'] = GMAIL_USER
+        msg['To'] = OWNER_EMAIL
+
+        with smtplib.SMTP('smtp.gmail.com', 587) as server:
+            server.starttls()
+            server.login(GMAIL_USER, GMAIL_PASS)
+            server.sendmail(msg['From'], [msg['To']], msg.as_string())
+
+lyra = LyraAI()
+
+# --- ADMIN AUTH ---
+@app.route("/verify_admin", methods=["POST"])
+def verify_admin():
+    data = request.get_json()
+    password = data.get("password")
+    if password == ADMIN_PASSWORD:
+        return jsonify({"access": True})
+    return jsonify({"access": False})
+
+# --- TERMINAL COMMAND ---
+@app.route("/run_command", methods=["POST"])
+def run_command():
+    data = request.get_json()
+    password = data.get("password")
+    command = data.get("command", "")
+    if password != ADMIN_PASSWORD:
+        return jsonify({"output": "Unauthorized"}), 403
     try:
-        data = json.loads(input_text or "{}")
-        result = asyncio.run(controller.route(agent_name, data))
-        st.json(result)
-    except ValueError as e:
-        st.error(str(e))
+        output = subprocess.check_output(
+            command, shell=True, stderr=subprocess.STDOUT, timeout=10, text=True
+        )
+    except subprocess.CalledProcessError as e:
+        output = e.output
     except Exception as e:
-        st.error("Error processing request")
+        output = str(e)
+    return jsonify({"output": output})
 
-if controller.memory:
-    st.subheader("History")
-    for sid, entries in controller.memory.fetch_all().items():
-        st.write(f"Session {sid}:")
-        for item in entries:
-            st.json(item)
+# --- LYRA ENDPOINTS ---
+@app.route("/speak", methods=["POST"])
+def speak():
+    text = request.json.get("text", "")
+    mood = request.json.get("mood", "neutral")
+    tts = gTTS(text=f"[{mood}] {text}", lang="en")
+    audio_buffer = io.BytesIO()
+    tts.write_to_fp(audio_buffer)
+    audio_buffer.seek(0)
+    return send_file(audio_buffer, mimetype="audio/mpeg")
+
+@app.route("/listen", methods=["GET"])
+def listen():
+    recognizer = sr.Recognizer()
+    with sr.Microphone() as source:
+        print("Listening...")
+        audio = recognizer.listen(source)
+    try:
+        transcript = recognizer.recognize_google(audio)
+    except Exception:
+        transcript = ""
+    return jsonify({"transcript": transcript})
+
+@app.route("/daily_report", methods=["GET"])
+def daily_report_api():
+    report_text = lyra.daily_report()
+
+    try:
+        msg = MIMEText(report_text)
+        msg['Subject'] = f"Lyra AI Update – {datetime.date.today().isoformat()}"
+        msg['From'] = GMAIL_USER
+        msg['To'] = OWNER_EMAIL
+
+        with smtplib.SMTP('smtp.gmail.com', 587) as server:
+            server.starttls()
+            server.login(GMAIL_USER, GMAIL_PASS)
+            server.sendmail(msg['From'], [msg['To']], msg.as_string())
+
+        status = "Report sent via email."
+    except Exception as e:
+        status = f"Report returned to chat, but email failed: {e}"
+
+    return jsonify({"status": status, "report": report_text})
+
+@app.route("/learn", methods=["POST"])
+def learn():
+    lyra.learn_security()
+    lyra.learn_medicine()
+    lyra.email_report()
+    return jsonify({"status": "Learning complete, email sent"})
+
+if __name__ == "__main__":
+    lyra.learn_security()
+    lyra.learn_medicine()
+    app.run(host="0.0.0.0", port=5000)
 

--- a/index.html
+++ b/index.html
@@ -3,14 +3,111 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AITaskFlo - Automation Tools</title>
-    <link rel="stylesheet" href="style.css">
+    <title>Lyra Admin Dashboard</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        #dashboard { display: none; }
+        button { margin: 5px; }
+        pre { background: #f0f0f0; padding: 10px; }
+    </style>
 </head>
 <body>
-    <div class="container">
-        <h1>AITaskFlo AI Agent 🤖✨</h1>
-        <p>Automation Tools For The Future Of AI Workflows</p>
-        <a href="https://github.com/rcastrejon91/ai_agents" class="btn">View on GitHub</a>
+    <div id="login">
+        <h2>Admin Login</h2>
+        <input type="password" id="password" placeholder="Password" />
+        <button onclick="login()">Login</button>
+        <p id="login-status"></p>
     </div>
+
+    <div id="dashboard">
+        <h1>Lyra Admin Command Center</h1>
+        <div>
+            <button onclick="learn()">Learn</button>
+            <button onclick="dailyReport()">Daily Report</button>
+        </div>
+        <div>
+            <h3>Speak</h3>
+            <input id="speak-text" placeholder="Text to speak" />
+            <select id="speak-mood">
+                <option value="neutral">Neutral</option>
+                <option value="happy">Happy</option>
+                <option value="sad">Sad</option>
+            </select>
+            <button onclick="speak()">Speak</button>
+            <audio id="audio" controls></audio>
+        </div>
+        <div>
+            <h3>Listen</h3>
+            <button onclick="listen()">Listen</button>
+            <p id="transcript"></p>
+        </div>
+        <div>
+            <h3>Terminal</h3>
+            <input id="command" placeholder="Enter command" />
+            <button onclick="runCommand()">Run</button>
+            <pre id="terminal-output"></pre>
+        </div>
+    </div>
+
+    <script>
+    let adminPassword = "";
+
+    async function login() {
+        const pwd = document.getElementById('password').value;
+        const res = await fetch('/verify_admin', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ password: pwd })
+        });
+        const data = await res.json();
+        if (data.access) {
+            adminPassword = pwd;
+            document.getElementById('login').style.display = 'none';
+            document.getElementById('dashboard').style.display = 'block';
+        } else {
+            document.getElementById('login-status').innerText = 'Access denied';
+        }
+    }
+
+    async function learn() {
+        await fetch('/learn', { method: 'POST' });
+    }
+
+    async function dailyReport() {
+        const res = await fetch('/daily_report');
+        const data = await res.json();
+        alert(data.status + "\n\n" + data.report);
+    }
+
+    async function speak() {
+        const text = document.getElementById('speak-text').value;
+        const mood = document.getElementById('speak-mood').value;
+        const res = await fetch('/speak', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text: text, mood: mood })
+        });
+        const blob = await res.blob();
+        document.getElementById('audio').src = URL.createObjectURL(blob);
+    }
+
+    async function listen() {
+        const res = await fetch('/listen');
+        const data = await res.json();
+        document.getElementById('transcript').innerText = data.transcript;
+    }
+
+    async function runCommand() {
+        const command = document.getElementById('command').value;
+        const res = await fetch('/run_command', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ password: adminPassword, command: command })
+        });
+        const data = await res.json();
+        document.getElementById('terminal-output').innerText = data.output;
+    }
+    </script>
 </body>
 </html>
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,8 @@ openai>=1.40.0
 streamlit
 requests
 torch
+
+# Web interface
+Flask
+gTTS
+SpeechRecognition


### PR DESCRIPTION
## Summary
- Replace Streamlit stub with Flask backend for Lyra AI featuring admin authentication, speech and listening endpoints, daily reports, and a terminal command runner
- Add web-based admin dashboard with login, controls for Learn/Daily Report/Speak/Listen, and an embedded command terminal
- Include Flask, gTTS, and SpeechRecognition in project requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d77896600832e9d35ce4c758e12ae