### PR TITLE
Add GPT chat integration and admin panel

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,42 +1,171 @@
-from __future__ import annotations
+from flask import Flask, request, jsonify, send_file
+import datetime
+import smtplib
+from email.mime.text import MIMEText
+import io
+from gtts import gTTS
+import speech_recognition as sr
+import subprocess
+import os
+from openai import OpenAI
 
-import json
-import asyncio
+# --- CONFIG ---
+OWNER_NAME = "Ricky"
+OWNER_EMAIL = "ricardomcastrejon@gmail.com"
+GMAIL_USER = os.getenv("GMAIL_USER")
+GMAIL_PASS = os.getenv("GMAIL_PASS")
+ADMIN_PASSWORD = os.getenv("ADMIN_PASS", "supersecret")
 
-import streamlit as st
-import pandas as pd
+client = OpenAI()  # uses OPENAI_API_KEY from environment
 
-from controller import AgentController
+app = Flask(__name__)
 
-controller = AgentController(enable_memory=True)
+# --- LYRA CLASS ---
+class LyraAI:
+    def __init__(self):
+        self.security_protocols = []
+        self.medical_knowledge_base = {}
+        self.security_knowledge_base = {}
+        self.self_learning_log = []
+        self.muted = False
+        self.current_mood = "neutral"
 
-st.title("AITaskFlo")
+    def learn_security(self):
+        learned_data = {
+            "date": datetime.date.today().isoformat(),
+            "new_threats": ["Ransomware variant X", "Zero-day in medical device firmware"],
+            "new_protections": ["Firewall AI patch", "Updated encryption protocol"],
+        }
+        self.security_knowledge_base[learned_data["date"]] = learned_data
+        self.security_protocols.extend(learned_data["new_protections"])
+        self.log_learning("Security", learned_data)
 
-agent_name = st.selectbox("Choose an agent", list(controller.available_agents().keys()))
-input_text = st.text_area("Input JSON", "{}")
+    def learn_medicine(self):
+        learned_data = {
+            "date": datetime.date.today().isoformat(),
+            "new_studies": ["Breakthrough in cancer immunotherapy", "Faster stroke detection AI"],
+            "new_treatments": ["Custom CRISPR gene repair", "AI-assisted MRI diagnosis"],
+        }
+        self.medical_knowledge_base[learned_data["date"]] = learned_data
+        self.log_learning("Medical", learned_data)
 
-if st.button("Run"):
+    def log_learning(self, category, data):
+        entry = {
+            "timestamp": datetime.datetime.now().isoformat(),
+            "category": category,
+            "data": data,
+        }
+        self.self_learning_log.append(entry)
+
+    def daily_report(self):
+        report = f"LYRA DAILY REPORT – {datetime.date.today().isoformat()}\n\n"
+        if self.security_knowledge_base.get(datetime.date.today().isoformat()):
+            sec = self.security_knowledge_base[datetime.date.today().isoformat()]
+            report += f"Security Threats: {', '.join(sec['new_threats'])}\n"
+            report += f"Protections: {', '.join(sec['new_protections'])}\n\n"
+        if self.medical_knowledge_base.get(datetime.date.today().isoformat()):
+            med = self.medical_knowledge_base[datetime.date.today().isoformat()]
+            report += f"Medical Studies: {', '.join(med['new_studies'])}\n"
+            report += f"New Treatments: {', '.join(med['new_treatments'])}\n\n"
+        report += f"Self-Learning Entries Today: {len(self.self_learning_log)}\n"
+        return report
+
+    def email_report(self):
+        if not GMAIL_USER or not GMAIL_PASS:
+            return
+        msg = MIMEText(self.daily_report())
+        msg['Subject'] = f"Lyra AI Update – {datetime.date.today().isoformat()}"
+        msg['From'] = GMAIL_USER
+        msg['To'] = OWNER_EMAIL
+
+        with smtplib.SMTP('smtp.gmail.com', 587) as server:
+            server.starttls()
+            server.login(GMAIL_USER, GMAIL_PASS)
+            server.sendmail(msg['From'], [msg['To']], msg.as_string())
+
+    def chat(self, text: str) -> str:
+        system_prompt = (
+            "You are Lyra, an AI assistant with expertise in cybersecurity and medicine. "
+            "Respond in Lyra's helpful and concise style."
+        )
+        completion = client.chat.completions.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": text},
+            ],
+        )
+        return completion.choices[0].message.content
+
+lyra = LyraAI()
+
+# --- ROUTES ---
+
+@app.route("/verify_admin", methods=["POST"])
+def verify_admin():
+    data = request.get_json()
+    if data.get("password") == ADMIN_PASSWORD:
+        return jsonify({"access": True})
+    return jsonify({"access": False})
+
+@app.route("/learn", methods=["POST"])
+def learn():
+    lyra.learn_security()
+    lyra.learn_medicine()
+    lyra.email_report()
+    return jsonify({"status": "Learning complete, email sent"})
+
+@app.route("/daily_report", methods=["GET"])
+def daily_report_api():
+    report_text = lyra.daily_report()
     try:
-        data = json.loads(input_text or "{}")
-        result = asyncio.run(controller.route(agent_name, data))
-        st.json(result)
-    except ValueError as e:
-        st.error(str(e))
+        lyra.email_report()
+        status = "Report sent via email."
     except Exception as e:
-        st.error("Error processing request")
+        status = f"Email failed: {e}"
+    return jsonify({"status": status, "report": report_text})
 
-if controller.memory:
-    st.subheader("History")
-    memory_data = controller.memory.fetch_all()
-    for sid, entries in memory_data.items():
-        st.write(f"Session {sid}:")
-        for item in entries:
-            st.json(item)
+@app.route("/chat", methods=["POST"])
+def chat_route():
+    user_text = request.json.get("text", "")
+    response = lyra.chat(user_text)
+    return jsonify({"response": response})
 
-    # Simple data visualization of session activity
-    session_counts = {sid: len(entries) for sid, entries in memory_data.items()}
-    if session_counts:
-        st.subheader("Session Activity")
-        df = pd.DataFrame(list(session_counts.items()), columns=["session", "entries"]).set_index("session")
-        st.bar_chart(df)
+@app.route("/speak", methods=["POST"])
+def speak():
+    text = request.json.get("text", "")
+    mood = request.json.get("mood", "neutral")
+    tts = gTTS(text=f"[{mood}] {text}", lang="en")
+    audio_buffer = io.BytesIO()
+    tts.write_to_fp(audio_buffer)
+    audio_buffer.seek(0)
+    return send_file(audio_buffer, mimetype="audio/mpeg")
 
+@app.route("/listen", methods=["GET"])
+def listen():
+    recognizer = sr.Recognizer()
+    with sr.Microphone() as source:
+        audio = recognizer.listen(source)
+    try:
+        transcript = recognizer.recognize_google(audio)
+    except Exception:
+        transcript = ""
+    return jsonify({"transcript": transcript})
+
+@app.route("/terminal", methods=["POST"])
+def terminal():
+    data = request.get_json()
+    cmd = data.get("command")
+    try:
+        result = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, text=True, timeout=10)
+    except subprocess.CalledProcessError as e:
+        result = e.output
+    except Exception as e:
+        result = str(e)
+    return jsonify({"output": result})
+
+if __name__ == "__main__":
+    lyra.learn_security()
+    lyra.learn_medicine()
+    lyra.email_report()
+    app.run(host="0.0.0.0", port=5000)

--- a/index.html
+++ b/index.html
@@ -3,14 +3,116 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AITaskFlo - Automation Tools</title>
-    <link rel="stylesheet" href="style.css">
+    <title>Lyra Admin Panel</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        #panel { display: none; }
+        textarea { width: 100%; height: 80px; }
+        .section { margin-bottom: 20px; }
+        #chatOutput { border: 1px solid #ccc; padding: 10px; height: 150px; overflow-y: auto; }
+    </style>
 </head>
 <body>
-    <div class="container">
-        <h1>AITaskFlo AI Agent 🤖✨</h1>
-        <p>Automation Tools For The Future Of AI Workflows</p>
-        <a href="https://github.com/rcastrejon91/ai_agents" class="btn">View on GitHub</a>
+    <div id="login">
+        <h2>Admin Login</h2>
+        <input type="password" id="password" placeholder="Password" />
+        <button id="loginBtn">Login</button>
     </div>
+
+    <div id="panel">
+        <h1>Lyra Admin Panel</h1>
+
+        <div class="section">
+            <h3>Chat</h3>
+            <div id="chatOutput"></div>
+            <textarea id="chatInput" placeholder="Type a message..."></textarea>
+            <button id="sendChat">Send</button>
+            <button id="listenBtn">Listen</button>
+        </div>
+
+        <div class="section">
+            <h3>Terminal</h3>
+            <textarea id="cmdInput" placeholder="Command"></textarea>
+            <button id="runCmd">Run</button>
+            <pre id="cmdOutput"></pre>
+        </div>
+
+        <div class="section">
+            <h3>Daily Report</h3>
+            <button id="reportBtn">Fetch Report</button>
+            <pre id="reportOutput"></pre>
+        </div>
+    </div>
+
+    <script>
+    async function login(){
+        const pw = document.getElementById('password').value;
+        const res = await fetch('/verify_admin', {
+            method: 'POST',
+            headers: {'Content-Type':'application/json'},
+            body: JSON.stringify({password: pw})
+        });
+        const data = await res.json();
+        if(data.access){
+            document.getElementById('login').style.display='none';
+            document.getElementById('panel').style.display='block';
+        } else {
+            alert('Access denied');
+        }
+    }
+    document.getElementById('loginBtn').onclick = login;
+
+    async function speak(text, mood='neutral'){
+        const res = await fetch('/speak',{
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body: JSON.stringify({text, mood})
+        });
+        const blob = await res.blob();
+        new Audio(URL.createObjectURL(blob)).play();
+    }
+
+    async function sendChat(){
+        const text = document.getElementById('chatInput').value;
+        const res = await fetch('/chat',{
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body: JSON.stringify({text})
+        });
+        const data = await res.json();
+        const output = document.getElementById('chatOutput');
+        output.innerHTML += `<p><b>You:</b> ${text}</p>`;
+        output.innerHTML += `<p><b>Lyra:</b> ${data.response}</p>`;
+        speak(data.response);
+        output.scrollTop = output.scrollHeight;
+    }
+    document.getElementById('sendChat').onclick = sendChat;
+
+    async function listen(){
+        const res = await fetch('/listen');
+        const data = await res.json();
+        document.getElementById('chatInput').value = data.transcript || '';
+    }
+    document.getElementById('listenBtn').onclick = listen;
+
+    async function runCmd(){
+        const cmd = document.getElementById('cmdInput').value;
+        const res = await fetch('/terminal',{
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body: JSON.stringify({command: cmd})
+        });
+        const data = await res.json();
+        document.getElementById('cmdOutput').textContent = data.output;
+    }
+    document.getElementById('runCmd').onclick = runCmd;
+
+    async function getReport(){
+        const res = await fetch('/daily_report');
+        const data = await res.json();
+        document.getElementById('reportOutput').textContent = data.report;
+    }
+    document.getElementById('reportBtn').onclick = getReport;
+    </script>
 </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,6 @@ torch
 Flask==3.0.3
 Flask-Cors==4.0.0
 gTTS==2.5.4
+
+SpeechRecognition==3.10.0
+PyAudio==0.2.13


### PR DESCRIPTION
## Summary
- replace Streamlit app with Flask backend supporting voice, terminal commands, daily reports and new GPT-powered chat endpoint
- add password-protected admin panel with chat, terminal, and report features
- include SpeechRecognition and PyAudio dependencies

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d793819dc832e9c3011ec3e36bb87