### PR TITLE
feat: add secure admin command center

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Lyra Admin Command Center</title>
+    <style>
+        body { background-color: #111; color: #0f0; font-family: monospace; }
+        h1 { text-align: center; }
+        .section { margin: 20px; padding: 10px; border: 1px solid #0f0; }
+        textarea, input { width: 100%; background: #000; color: #0f0; border: 1px solid #0f0; }
+        button { background: #0f0; color: #000; font-weight: bold; padding: 5px 10px; cursor: pointer; }
+        #terminal-output { height: 200px; overflow-y: auto; background: #000; padding: 5px; }
+    </style>
+</head>
+<body>
+
+<h1>🛡️ Lyra Admin Command Center</h1>
+
+<!-- Admin Auth -->
+<div class="section">
+    <h3>Admin Login</h3>
+    <input type="password" id="adminKey" placeholder="Enter admin key...">
+    <button onclick="loginAdmin()">Login</button>
+    <p id="loginStatus"></p>
+</div>
+
+<!-- Trigger Lyra Learning -->
+<div class="section">
+    <h3>📚 Trigger Lyra Learning</h3>
+    <button onclick="triggerLearning()">Run Learning Protocols</button>
+</div>
+
+<!-- View Private Reports -->
+<div class="section">
+    <h3>📩 Fetch Private Daily Report</h3>
+    <button onclick="fetchPrivateReport()">Get Report</button>
+    <pre id="privateReport"></pre>
+</div>
+
+<!-- Terminal -->
+<div class="section">
+    <h3>💻 Remote Terminal</h3>
+    <textarea id="terminalCommand" placeholder="Enter command..."></textarea>
+    <button onclick="runTerminalCommand()">Run</button>
+    <div id="terminal-output"></div>
+</div>
+
+<script>
+const LYRA_API_URL = "http://localhost:5000";
+let isAdmin = false;
+let adminKey = "";
+
+function loginAdmin() {
+    const key = document.getElementById("adminKey").value;
+    // Replace 'YOUR_SECRET_KEY' with your real key in environment variables
+    if (key === "YOUR_SECRET_KEY") {
+        isAdmin = true;
+        adminKey = key;
+        document.getElementById("loginStatus").innerText = "✅ Access Granted";
+    } else {
+        document.getElementById("loginStatus").innerText = "❌ Access Denied";
+    }
+}
+
+async function triggerLearning() {
+    if (!isAdmin) return alert("Unauthorized");
+    const res = await fetch(`${LYRA_API_URL}/learn`, {
+        method: "POST",
+        headers: { "Admin-Key": adminKey }
+    });
+    const data = await res.json();
+    alert(data.status);
+}
+
+async function fetchPrivateReport() {
+    if (!isAdmin) return alert("Unauthorized");
+    const res = await fetch(`${LYRA_API_URL}/daily_report`, {
+        headers: { "Admin-Key": adminKey }
+    });
+    const data = await res.json();
+    document.getElementById("privateReport").innerText = data.report;
+}
+
+async function runTerminalCommand() {
+    if (!isAdmin) return alert("Unauthorized");
+    const cmd = document.getElementById("terminalCommand").value;
+    const res = await fetch(`${LYRA_API_URL}/terminal`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "Admin-Key": adminKey },
+        body: JSON.stringify({ command: cmd })
+    });
+    const data = await res.json();
+    document.getElementById("terminal-output").innerHTML += `<div>$ ${cmd}<br>${data.output}</div>`;
+}
+</script>
+
+</body>
+</html>

--- a/lyra_admin/app.py
+++ b/lyra_admin/app.py
@@ -6,6 +6,7 @@ import io
 from gtts import gTTS
 import speech_recognition as sr
 import subprocess
+import os
 
 # --- CONFIG ---
 OWNER_NAME = "Ricky"
@@ -13,6 +14,7 @@ OWNER_EMAIL = "ricardomcastrejon@gmail.com"
 GMAIL_USER = "YOUR_EMAIL"       # Set in env vars
 GMAIL_PASS = "YOUR_PASSWORD"    # Set in env vars
 ADMIN_PASSWORD = "supersecret"  # Change this
+ADMIN_KEY = os.getenv("LYRA_ADMIN_KEY", "YOUR_SECRET_KEY")
 
 app = Flask(__name__)
 
@@ -137,8 +139,12 @@ def listen():
 
 @app.route("/terminal", methods=["POST"])
 def terminal():
-    data = request.get_json()
-    cmd = data.get("command")
+    key = request.headers.get("Admin-Key") or ""
+    if key != ADMIN_KEY:
+        return jsonify({"error": "Unauthorized"}), 403
+
+    data = request.get_json() or {}
+    cmd = data.get("command", "")
     try:
         result = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, text=True, timeout=10)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Summary
- add dedicated admin dashboard for triggering learning, fetching daily reports, and running terminal commands
- secure terminal endpoint with `LYRA_ADMIN_KEY`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d7a2ca838832e84d3af26d4c60e7b