### PR TITLE
Add system stats monitoring to admin panel

### DIFF
--- a/lyra_admin/app.py
+++ b/lyra_admin/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, jsonify, send_file
+import psutil
 import datetime
 import smtplib
 from email.mime.text import MIMEText
@@ -146,6 +147,14 @@ def terminal():
     except Exception as e:
         result = str(e)
     return jsonify({"output": result})
+
+@app.route("/system_stats")
+def system_stats():
+    stats = {
+        "cpu": psutil.cpu_percent(interval=0.5),
+        "memory": psutil.virtual_memory().percent
+    }
+    return jsonify(stats)
 
 if __name__ == "__main__":
     lyra.learn_security()

--- a/lyra_admin/requirements.txt
+++ b/lyra_admin/requirements.txt
@@ -2,3 +2,4 @@ flask
 gTTS
 SpeechRecognition
 pyaudio
+psutil

--- a/lyra_admin/static/index.html
+++ b/lyra_admin/static/index.html
@@ -33,6 +33,10 @@
     <button onclick="lyraSpeakPrompt()">🗣 Speak</button>
     <button onclick="lyraListen()">🎤 Listen</button>
 
+    <h3>📊 System Vitals</h3>
+    <p>CPU: <span id="cpuUsage">0</span>%</p>
+    <p>Memory: <span id="memUsage">0</span>%</p>
+
     <h3>📜 Output Log</h3>
     <div id="chatLog" style="background:#111; padding:10px; height:200px; overflow:auto;"></div>
 
@@ -46,6 +50,7 @@
 const LYRA_API_URL = "http://localhost:5000";
 let isMuted = false;
 let currentMood = "neutral";
+let isAdmin = false;
 
 function verifyAdmin() {
     const password = document.getElementById("adminPass").value;
@@ -59,6 +64,7 @@ function verifyAdmin() {
         if (data.access) {
             document.getElementById("loginPanel").classList.add("hidden");
             document.getElementById("adminPanel").classList.remove("hidden");
+            isAdmin = true;
         } else {
             document.getElementById("loginStatus").innerText = "❌ Wrong password";
         }
@@ -117,6 +123,15 @@ function runCommand() {
 function appendMessage(sender, msg) {
     document.getElementById("chatLog").innerHTML += `<p><b>${sender}:</b> ${msg}</p>`;
 }
+
+async function updateVitals() {
+    if (!isAdmin) return;
+    const res = await fetch(`${LYRA_API_URL}/system_stats`);
+    const data = await res.json();
+    document.getElementById("cpuUsage").innerText = data.cpu.toFixed(1);
+    document.getElementById("memUsage").innerText = data.memory.toFixed(1);
+}
+setInterval(updateVitals, 2000);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose `/system_stats` endpoint providing CPU and memory usage
- display live system vitals on admin dashboard
- include `psutil` dependency

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d79e3ade0832e956d94d126d101bc