### PR TITLE
Integrate GPT chat and wire frontend

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -31,10 +31,25 @@ function autoDetectMood(message) {
 }
 
 document.getElementById("sendBtn").addEventListener("click", async () => {
-    const input = document.getElementById("chatInput").value;
+    const inputEl = document.getElementById("chatInput");
+    const input = inputEl.value.trim();
+    if (!input) return;
     autoDetectMood(input);
     appendMessage("You", input);
-    await lyraSpeak(input, currentMood);
+    inputEl.value = "";
+    try {
+        const res = await fetch(`${LYRA_API_URL}/chat`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ message: input })
+        });
+        const data = await res.json();
+        const reply = data.reply || "";
+        appendMessage("Lyra", reply);
+        await lyraSpeak(reply, currentMood);
+    } catch (err) {
+        appendMessage("Lyra", "Error: " + err.message);
+    }
 });
 
 document.getElementById("muteBtn").addEventListener("click", () => {
@@ -43,17 +58,17 @@ document.getElementById("muteBtn").addEventListener("click", () => {
 
 document.getElementById("runTerminalBtn").addEventListener("click", () => {
     const code = document.getElementById("terminalInput").value;
-    fetch(`${LYRA_API_URL}/run_code`, {
+    fetch(`${LYRA_API_URL}/terminal`, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
             "X-Admin-Key": ADMIN_KEY
         },
-        body: JSON.stringify({ code })
+        body: JSON.stringify({ command: code })
     })
     .then(res => res.json())
     .then(data => {
-        appendMessage("Terminal Output", data.result || data.error);
+        appendMessage("Terminal Output", data.output || data.error);
     });
 });
 

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -18,7 +18,7 @@ export default function Home() {
     });
     const data = await res.json();
 
-    setMessages((prev) => [...prev, { sender: "user", text }, { sender: "lyra", text: data.response }]);
+    setMessages((prev) => [...prev, { sender: "user", text }, { sender: "lyra", text: data.reply }]);
   };
 
   return (

--- a/lyra-ai/frontend/components/ChatBox.js
+++ b/lyra-ai/frontend/components/ChatBox.js
@@ -18,9 +18,9 @@ export default function ChatBox({ muted }) {
         body: JSON.stringify({ message: userMessage })
       });
       const data = await res.json();
-      setMessages(prev => [...prev, { sender: 'lyra', text: data.response }]);
+      setMessages(prev => [...prev, { sender: 'lyra', text: data.reply }]);
       if (!muted && typeof window !== 'undefined') {
-        const utter = new SpeechSynthesisUtterance(data.response);
+        const utter = new SpeechSynthesisUtterance(data.reply);
         window.speechSynthesis.speak(utter);
       }
     } catch (err) {


### PR DESCRIPTION
## Summary
- replace OpenAI client usage with `openai.ChatCompletion` and add `/chat` endpoint
- wire dashboard and React front-ends to new `/chat` responses and terminal endpoint

## Testing
- `pytest`
- `cd frontend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d795542ac832e92b0df5503be48f3