### PR TITLE
Add Lyra web templates and static assets

### DIFF
--- a/static/admin.js
+++ b/static/admin.js
@@ -1,0 +1,16 @@
+document.getElementById("runCommand").addEventListener("click", async () => {
+    const cmd = document.getElementById("terminalCommand").value;
+    const res = await fetch("/admin/terminal", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ command: cmd })
+    });
+    const data = await res.json();
+    document.getElementById("terminalOutput").innerText += data.output + "\n";
+});
+
+document.getElementById("getReport").addEventListener("click", async () => {
+    const res = await fetch("/daily_report");
+    const data = await res.json();
+    document.getElementById("reportOutput").innerText = data.report;
+});

--- a/static/style.css
+++ b/static/style.css
@@ -1,44 +1,40 @@
 body {
     font-family: Arial, sans-serif;
+    background-color: #1c1c1c;
+    color: #fff;
     margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    height: 100vh;
 }
 
-header {
-    background: #222;
-    color: white;
+header, footer {
+    background-color: #222;
     padding: 10px;
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    justify-content: space-between;
 }
 
-main {
-    flex: 1;
-    padding: 10px;
+#chatLog {
+    padding: 20px;
+    height: 70vh;
     overflow-y: auto;
-    background: #f4f4f4;
+    background-color: #111;
 }
 
-footer {
-    display: flex;
-    border-top: 1px solid #ccc;
+#chatInput {
+    width: 80%;
+    padding: 8px;
 }
 
-footer input {
-    flex: 1;
-    padding: 10px;
+#sendBtn {
+    width: 18%;
+    padding: 8px;
+    background-color: #444;
     border: none;
-    outline: none;
-}
-
-footer button {
-    padding: 10px 20px;
-    border: none;
-    background: #222;
     color: white;
     cursor: pointer;
+}
+
+.admin-link {
+    color: #0af;
+    text-decoration: none;
 }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Lyra Admin Dashboard</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <h1>🛠 Lyra Admin Dashboard</h1>
+
+    <section>
+        <h2>Terminal</h2>
+        <pre id="terminalOutput"></pre>
+        <input id="terminalCommand" placeholder="Type command">
+        <button id="runCommand">Run</button>
+    </section>
+
+    <section>
+        <h2>Daily Report</h2>
+        <button id="getReport">Get Report</button>
+        <pre id="reportOutput"></pre>
+    </section>
+
+    <script src="/static/admin.js"></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 <head>
     <meta charset="UTF-8">
     <title>Lyra AI Chat</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+    <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
     <header>
         <h1>💬 Lyra AI</h1>
         <button id="muteBtn">🔇 Mute</button>
+        <a href="/login" class="admin-link">Admin Login</a>
     </header>
 
     <main id="chatLog"></main>
@@ -18,9 +19,6 @@
         <button id="sendBtn">Send</button>
     </footer>
 
-    <script>
-        const LYRA_API_URL = window.location.origin;
-    </script>
-    <script src="{{ url_for('static', filename='script.js') }}"></script>
+    <script src="/static/script.js"></script>
 </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Lyra Login</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <h1>🔐 Login</h1>
+    <form method="POST">
+        <input type="email" name="email" placeholder="Email" required>
+        <input type="password" name="password" placeholder="Password" required>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add chat interface template with admin link
- Introduce admin dashboard and login templates
- Provide supporting JavaScript and CSS for chat and admin features

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e472a7730832ea8a10a052680743b