### PR TITLE
Add Lyra chat front-end template and styling

### DIFF
--- a/lyra_app/static/style.css
+++ b/lyra_app/static/style.css
@@ -1,0 +1,48 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+}
+
+header {
+    background: #222;
+    color: white;
+    padding: 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+main {
+    flex: 1;
+    padding: 10px;
+    overflow-y: auto;
+    background: #f4f4f4;
+}
+
+footer {
+    display: flex;
+    border-top: 1px solid #ccc;
+}
+
+footer input {
+    flex: 1;
+    padding: 10px;
+    border: none;
+    outline: none;
+}
+
+footer button {
+    padding: 10px 20px;
+    border: none;
+    background: #222;
+    color: white;
+    cursor: pointer;
+}
+
+#chatLog p {
+    margin: 5px 0;
+}

--- a/lyra_app/templates/index.html
+++ b/lyra_app/templates/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Lyra AI</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <header>
+        <h1>💬 Lyra AI</h1>
+        <button id="muteBtn">🔇 Mute</button>
+    </header>
+
+    <main id="chatLog"></main>
+
+    <footer>
+        <input id="chatInput" type="text" placeholder="Type your message..." />
+        <button id="sendBtn">Send</button>
+    </footer>
+
+    <script>
+        const LYRA_API_URL = window.location.origin;
+        let isMuted = false;
+        let currentMood = "neutral";
+
+        function appendMessage(sender, message) {
+            const log = document.getElementById("chatLog");
+            log.innerHTML += `<p><b>${sender}:</b> ${message}</p>`;
+            log.scrollTop = log.scrollHeight;
+        }
+
+        async function lyraSpeak(text, mood = currentMood) {
+            if (isMuted) return;
+            const res = await fetch(`${LYRA_API_URL}/speak`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ text, mood })
+            });
+            const audioBlob = await res.blob();
+            const audioUrl = URL.createObjectURL(audioBlob);
+            new Audio(audioUrl).play();
+        }
+
+        function autoDetectMood(message) {
+            if (message.includes("sad")) currentMood = "calm";
+            else if (message.includes("excited")) currentMood = "cheerful";
+            else currentMood = "neutral";
+        }
+
+        document.getElementById("sendBtn").addEventListener("click", async () => {
+            const input = document.getElementById("chatInput");
+            const text = input.value.trim();
+            if (!text) return;
+            appendMessage("You", text);
+            autoDetectMood(text);
+
+            // Echo for now — connect to GPT or backend here
+            appendMessage("Lyra", text);
+            await lyraSpeak(text);
+            input.value = "";
+        });
+
+        document.getElementById("muteBtn").addEventListener("click", () => {
+            isMuted = !isMuted;
+            document.getElementById("muteBtn").textContent = isMuted ? "🔊 Unmute" : "🔇 Mute";
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Create `lyra_app/templates/index.html` for Lyra web chat with mood-based text-to-speech and mute control
- Add `lyra_app/static/style.css` to style chat layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e2f1b6bfc832e97b1d412d96aa8bd