### PR TITLE
Add Lyra web app scaffold

### DIFF
--- a/lyra_app/app.py
+++ b/lyra_app/app.py
@@ -1,0 +1,162 @@
+import os
+import datetime
+import smtplib
+from email.mime.text import MIMEText
+from flask import Flask, request, jsonify, send_file, render_template, redirect, url_for, session
+import io
+from gtts import gTTS
+import speech_recognition as sr
+from functools import wraps
+import subprocess
+import secrets
+
+# --- CONFIG ---
+OWNER_NAME = "Ricky"
+OWNER_EMAIL = "ricardomcastrejon@gmail.com"
+GMAIL_USER = os.getenv("GMAIL_USER")
+GMAIL_PASS = os.getenv("GMAIL_PASS")
+ADMIN_PASSWORD = os.getenv("ADMIN_PASSWORD", "changeme")
+
+app = Flask(__name__)
+app.secret_key = os.getenv("SECRET_KEY", secrets.token_hex(16))
+
+# --- CORE CLASS ---
+class LyraAI:
+    def __init__(self):
+        self.security_protocols = []
+        self.medical_knowledge_base = {}
+        self.security_knowledge_base = {}
+        self.self_learning_log = []
+        self.muted = False
+        self.current_mood = "neutral"
+
+    def learn_security(self):
+        learned_data = {
+            "date": datetime.date.today().isoformat(),
+            "new_threats": ["Ransomware variant X", "Zero-day in medical device firmware"],
+            "new_protections": ["Firewall AI patch", "Updated encryption protocol"]
+        }
+        self.security_knowledge_base[learned_data["date"]] = learned_data
+        self.security_protocols.extend(learned_data["new_protections"])
+        self.log_learning("Security", learned_data)
+
+    def learn_medicine(self):
+        learned_data = {
+            "date": datetime.date.today().isoformat(),
+            "new_studies": ["Breakthrough in cancer immunotherapy", "Faster stroke detection AI"],
+            "new_treatments": ["Custom CRISPR gene repair", "AI-assisted MRI diagnosis"]
+        }
+        self.medical_knowledge_base[learned_data["date"]] = learned_data
+        self.log_learning("Medical", learned_data)
+
+    def log_learning(self, category, data):
+        entry = {
+            "timestamp": datetime.datetime.now().isoformat(),
+            "category": category,
+            "data": data
+        }
+        self.self_learning_log.append(entry)
+
+    def daily_report(self):
+        report = f"LYRA DAILY REPORT – {datetime.date.today().isoformat()}\n\n"
+        if self.security_knowledge_base.get(datetime.date.today().isoformat()):
+            sec = self.security_knowledge_base[datetime.date.today().isoformat()]
+            report += f"Security Threats: {', '.join(sec['new_threats'])}\n"
+            report += f"Protections: {', '.join(sec['new_protections'])}\n\n"
+        if self.medical_knowledge_base.get(datetime.date.today().isoformat()):
+            med = self.medical_knowledge_base[datetime.date.today().isoformat()]
+            report += f"Medical Studies: {', '.join(med['new_studies'])}\n"
+            report += f"New Treatments: {', '.join(med['new_treatments'])}\n\n"
+        report += f"Self-Learning Entries Today: {len(self.self_learning_log)}\n"
+        return report
+
+    def email_report(self):
+        msg = MIMEText(self.daily_report())
+        msg['Subject'] = f"Lyra AI Update – {datetime.date.today().isoformat()}"
+        msg['From'] = GMAIL_USER
+        msg['To'] = OWNER_EMAIL
+        with smtplib.SMTP('smtp.gmail.com', 587) as server:
+            server.starttls()
+            server.login(GMAIL_USER, GMAIL_PASS)
+            server.sendmail(msg['From'], [msg['To']], msg.as_string())
+
+lyra = LyraAI()
+
+# --- AUTH DECORATOR ---
+def admin_required(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        if session.get("admin_logged_in"):
+            return f(*args, **kwargs)
+        return redirect(url_for("admin_login"))
+    return wrapper
+
+# --- ROUTES ---
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+@app.route("/speak", methods=["POST"])
+def speak():
+    text = request.json.get("text", "")
+    mood = request.json.get("mood", "neutral")
+    tts = gTTS(text=f"[{mood}] {text}", lang="en")
+    audio_buffer = io.BytesIO()
+    tts.write_to_fp(audio_buffer)
+    audio_buffer.seek(0)
+    return send_file(audio_buffer, mimetype="audio/mpeg")
+
+@app.route("/listen", methods=["GET"])
+def listen():
+    recognizer = sr.Recognizer()
+    with sr.Microphone() as source:
+        audio = recognizer.listen(source)
+    try:
+        transcript = recognizer.recognize_google(audio)
+    except:
+        transcript = ""
+    return jsonify({"transcript": transcript})
+
+@app.route("/learn", methods=["POST"])
+def learn():
+    lyra.learn_security()
+    lyra.learn_medicine()
+    lyra.email_report()
+    return jsonify({"status": "Learning complete, email sent"})
+
+@app.route("/daily_report", methods=["GET"])
+def daily_report_api():
+    report_text = lyra.daily_report()
+    try:
+        lyra.email_report()
+        status = "Report sent via email."
+    except Exception as e:
+        status = f"Report generated, email failed: {e}"
+    return jsonify({"status": status, "report": report_text})
+
+# --- ADMIN PANEL ---
+@app.route("/admin", methods=["GET"])
+@admin_required
+def admin_panel():
+    return render_template("admin.html")
+
+@app.route("/admin/login", methods=["GET", "POST"])
+def admin_login():
+    if request.method == "POST":
+        if request.form.get("password") == ADMIN_PASSWORD:
+            session["admin_logged_in"] = True
+            return redirect(url_for("admin_panel"))
+    return render_template("login.html")
+
+@app.route("/admin/terminal", methods=["POST"])
+@admin_required
+def admin_terminal():
+    cmd = request.json.get("command")
+    try:
+        output = subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT, text=True)
+    except subprocess.CalledProcessError as e:
+        output = e.output
+    return jsonify({"output": output})
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/lyra_app/requirements.txt
+++ b/lyra_app/requirements.txt
@@ -1,0 +1,5 @@
+flask
+gtts
+SpeechRecognition
+gunicorn
+apscheduler

--- a/lyra_app/static/admin.js
+++ b/lyra_app/static/admin.js
@@ -1,0 +1,33 @@
+const ADMIN_API_URL = "http://localhost:5000";
+
+document.getElementById("getReportBtn").addEventListener("click", () => {
+    fetch(`${ADMIN_API_URL}/daily_report`)
+        .then(res => res.json())
+        .then(data => {
+            document.getElementById("output").textContent = data.report;
+        })
+        .catch(err => console.error(err));
+});
+
+document.getElementById("learnBtn").addEventListener("click", () => {
+    fetch(`${ADMIN_API_URL}/learn`, { method: "POST" })
+        .then(res => res.json())
+        .then(data => {
+            document.getElementById("output").textContent = data.status;
+        })
+        .catch(err => console.error(err));
+});
+
+document.getElementById("runTerminalBtn").addEventListener("click", () => {
+    const command = document.getElementById("terminalInput").value;
+    fetch(`${ADMIN_API_URL}/admin/terminal`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ command })
+    })
+    .then(res => res.json())
+    .then(data => {
+        document.getElementById("output").textContent = data.output;
+    })
+    .catch(err => console.error(err));
+});

--- a/lyra_app/static/script.js
+++ b/lyra_app/static/script.js
@@ -1,0 +1,56 @@
+const LYRA_API_URL = "http://localhost:5000";
+let isMuted = false;
+let currentMood = "neutral";
+
+function appendMessage(sender, message) {
+    document.getElementById("chatLog").innerHTML += `<p><b>${sender}:</b> ${message}</p>`;
+}
+
+// --- TEXT TO SPEECH ---
+async function lyraSpeak(text, mood = currentMood) {
+    if (isMuted) return;
+    const res = await fetch(`${LYRA_API_URL}/speak`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text, mood })
+    });
+    const audioBlob = await res.blob();
+    const audioUrl = URL.createObjectURL(audioBlob);
+    new Audio(audioUrl).play();
+}
+
+// --- SPEECH TO TEXT ---
+async function lyraListen() {
+    const res = await fetch(`${LYRA_API_URL}/listen`);
+    const data = await res.json();
+    appendMessage("You", data.transcript);
+    return data.transcript;
+}
+
+// --- MUTE / UNMUTE ---
+function toggleMute() {
+    isMuted = !isMuted;
+    console.log(`Muted: ${isMuted}`);
+}
+
+// --- CHANGE MOOD ---
+function setMood(mood) {
+    currentMood = mood;
+}
+
+// --- AUTO MOOD DETECTION ---
+function autoDetectMood(message) {
+    if (message.includes("sad")) currentMood = "calm";
+    else if (message.includes("excited")) currentMood = "cheerful";
+    else currentMood = "neutral";
+}
+
+document.getElementById("sendBtn").addEventListener("click", async () => {
+    const input = document.getElementById("chatInput").value;
+    autoDetectMood(input);
+    appendMessage("You", input);
+    await lyraSpeak(input);
+    document.getElementById("chatInput").value = "";
+});
+
+document.getElementById("muteBtn").addEventListener("click", toggleMute);

--- a/lyra_app/static/style.css
+++ b/lyra_app/static/style.css
@@ -1,0 +1,48 @@
+body {
+    font-family: Arial, sans-serif;
+    background-color: #121212;
+    color: #fff;
+    padding: 20px;
+}
+
+#chatContainer {
+    max-width: 600px;
+    margin: auto;
+    background: #1e1e1e;
+    padding: 20px;
+    border-radius: 10px;
+}
+
+#chatLog {
+    height: 300px;
+    overflow-y: auto;
+    border: 1px solid #333;
+    padding: 10px;
+    background: #000;
+    margin-bottom: 10px;
+}
+
+#chatInput {
+    width: 70%;
+    padding: 10px;
+}
+
+button {
+    padding: 10px;
+    background: #00bfff;
+    border: none;
+    color: white;
+    cursor: pointer;
+}
+
+button:hover {
+    background: #008fcc;
+}
+
+textarea {
+    width: 100%;
+    height: 100px;
+    background: #000;
+    color: #0f0;
+    font-family: monospace;
+}

--- a/lyra_app/templates/admin.html
+++ b/lyra_app/templates/admin.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Lyra Admin Dashboard</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Lyra Admin Command Center</h1>
+    <button id="getReportBtn">📅 Get Daily Report</button>
+    <button id="learnBtn">📚 Force Learn</button>
+    <h2>Output</h2>
+    <pre id="output"></pre>
+
+    <h2>Live Terminal</h2>
+    <textarea id="terminalInput" placeholder="Type Python code..."></textarea>
+    <button id="runTerminalBtn">Run Code</button>
+
+    <script src="{{ url_for('static', filename='admin.js') }}"></script>
+</body>
+</html>

--- a/lyra_app/templates/index.html
+++ b/lyra_app/templates/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Lyra AI Chat</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <div id="chatContainer">
+        <div id="chatLog"></div>
+        <input type="text" id="chatInput" placeholder="Type your message...">
+        <button id="sendBtn">Send</button>
+        <button id="muteBtn">Mute</button>
+    </div>
+    <script src="{{ url_for('static', filename='script.js') }}"></script>
+</body>
+</html>

--- a/lyra_app/templates/login.html
+++ b/lyra_app/templates/login.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Login</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <h1>Admin Login</h1>
+    <form method="post">
+        <input type="password" name="password" placeholder="Password">
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask-based Lyra backend with speech, learning and admin features
- include chat, admin and login templates plus associated JS and CSS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e141e0778832e948e0b546f3df34d