### PR TITLE
Add diagnostic doctor and GPT4All fallback for Lyra AI

### DIFF
--- a/doctor.py
+++ b/doctor.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import importlib
+import traceback
+import platform
+
+
+def ok(label):
+    print(f"✅ {label}")
+
+
+def bad(label, e=""):
+    print(f"❌ {label}\n{e}")
+
+
+print("=== Lyra System Doctor ===")
+print("Python:", sys.version)
+print("Platform:", platform.platform())
+
+# 1) modules
+for mod in ["flask", "flask_cors", "gpt4all"]:
+    try:
+        importlib.import_module(mod.replace("flask_cors", "flask_cors"))
+        ok(f"import {mod}")
+    except Exception as e:
+        bad(f"import {mod}", traceback.format_exc())
+
+# 2) package init files
+paths = ["agents", "lyra_core", "robot_core"]
+for p in paths:
+    ip = os.path.join(p, "__init__.py")
+    if os.path.isdir(p) and not os.path.exists(ip):
+        bad(f"missing {ip}")
+    else:
+        ok(f"{p}/__init__.py exists")
+
+# 3) model availability
+model = "Meta-Llama-3-8B-Instruct.Q4_0.gguf"
+models_dir = os.path.expanduser("~/.cache/gpt4all")
+candidate = os.path.join(models_dir, model)
+if os.path.exists(candidate):
+    ok(f"model found: {candidate}")
+else:
+    print(f"ℹ️ model not found at {candidate} (will attempt download on first run)")
+
+# 4) import orchestrator
+try:
+    from lyra_core.lyra_ai import LyraAI
+    ok("import lyra_core.lyra_ai:LyraAI")
+except Exception as e:
+    bad("import lyra_core.lyra_ai", traceback.format_exc())
+
+print("=== Done ===")
+

--- a/lyra_core/lyra_ai.py
+++ b/lyra_core/lyra_ai.py
@@ -1,23 +1,51 @@
-from gpt4all import GPT4All
-
-from lyra_core.guardian_phase_two import AstralShield, Guardian
-from lyra_core.inner_focus_engine import InnerFocusEngine
-from lyra_core.scene_soul_driver import SceneSoulDriver
 from lyra_core.world_state_engine import WorldStateEngine
+from lyra_core.scene_soul_driver import SceneSoulDriver
+from lyra_core.inner_focus_engine import InnerFocusEngine
+from lyra_core.guardian_phase_two import Guardian, AstralShield
 from manager import AgentManager
 
 
+class _LLMStub:
+    def chat(self, prompt: str) -> str:
+        # very basic router mimic
+        low = prompt.lower()
+        if "stock" in low or "tesla" in low or "price" in low:
+            return "CALL:finance: " + prompt
+        if "law" in low or "statute" in low or "contract" in low:
+            return "CALL:legal: " + prompt
+        if "appointment" in low or "book" in low or "reservation" in low:
+            return "CALL:concierge: " + prompt
+        if "health" in low or "symptom" in low:
+            return "CALL:healthcare: " + prompt
+        if "retail" in low or "sku" in low:
+            return "CALL:retail: " + prompt
+        return "Lyra(stub): " + prompt
+
+
+try:
+    from gpt4all import GPT4All
+
+    _gpt = GPT4All("Meta-Llama-3-8B-Instruct.Q4_0.gguf")
+
+    def llm_answer(msg: str) -> str:
+        with _gpt.chat_session():
+            return _gpt.generate(
+                "You are Lyra, a router. Use CALL:<agent>:<query> when delegation fits; else answer."
+                f"\nUser: {msg}",
+                max_tokens=160,
+            ).strip()
+
+except Exception as _e:
+    _gpt = None
+
+    def llm_answer(msg: str) -> str:
+        return _LLMStub().chat(msg)
+
+
 class LyraAI:
-    def __init__(
-        self,
-        owner_name: str,
-        owner_email: str,
-        model="Meta-Llama-3-8B-Instruct.Q4_0.gguf",
-    ):
+    def __init__(self, owner_name: str, owner_email: str):
         self.owner_name = owner_name
         self.owner_email = owner_email
-        self.llm = GPT4All(model)
-        # subsystems
         self.manager = AgentManager()
         self.world = WorldStateEngine()
         self.scene = SceneSoulDriver()
@@ -26,42 +54,32 @@ class LyraAI:
         self.shield = AstralShield()
 
     def _delegate_or_answer(self, msg: str) -> str:
-        # Basic router prompt — Lyra can answer or call agents
-        with self.llm.chat_session():
-            route = self.llm.generate(
-                "You are Lyra, an orchestrator. "
-                "If the user asks about stocks, reply exactly 'CALL:finance:<query>'. "
-                "Legal → 'CALL:legal:<query>'. Healthcare → 'CALL:healthcare:<query>'. "
-                "Retail/business ops → 'CALL:retail:<query>'. Concierge/scheduling → 'CALL:concierge:<query>'. "
-                "Otherwise answer directly.\n\nUser: " + msg,
-                max_tokens=120,
-            ).strip()
-
+        route = llm_answer(msg)
         if route.startswith("CALL:"):
             _, agent, query = route.split(":", 2)
             return self.manager.dispatch(agent.strip(), query.strip())
         return route
 
     def respond(self, message: str, emotion: str = None, env=None) -> str:
-        # Track inner focus + world state
-        self.focus.add_focus(message, intensity=1.0, emotion=emotion)
+        # inner/world/scene hooks
+        self.focus.add_focus(message, 1.0, emotion)
         self.world.add_event({"type": "user_input", "text": message})
         if emotion:
             self.world.react_to_emotion(emotion)
             self.scene.match_scene_to_emotion(emotion)
 
-        # Safety envelope (environment monitoring)
+        # safety: guardian text scan
+        g = self.guardian.scan_text(message)
+        if g:
+            return g
+
+        # safety: environment watch
         if env:
             hazard = self.world.monitor_environment(env)
             if hazard != "Environment stable":
                 return self.shield.emergency_stop() + f" ({hazard})"
 
-        # Guardian intercept (ban words / clamp can be applied inside agents too)
-        guard_check = self.guardian.scan_text(message)
-        if guard_check is not None:
-            return guard_check
-
-        # Answer or delegate
         reply = self._delegate_or_answer(message)
-        self.world.add_event({"type": "lyra_reply", "text": reply})
+        self.world.add_event({"type": "reply", "text": reply})
         return reply
+


### PR DESCRIPTION
## Summary
- add `doctor.py` script to validate dependencies, package init files, model availability, and LyraAI import
- replace Lyra AI orchestrator with GPT4All-based implementation that falls back to a stub router

## Testing
- `python doctor.py`
- `pytest`
- `curl -s -X POST localhost:5000/chat -H "Content-Type: application/json" -d '{"message":"check Tesla stock"}'`


------
https://chatgpt.com/codex/tasks/task_e_68a55391b8a4832e848ac481469d3d33